### PR TITLE
Compress user_data using gzip to avoid to exceed the hard limit (32KB)

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -172,8 +172,10 @@ func (r *CloudStackMachineReconciler) reconcile(
 
 	buf := &bytes.Buffer{}
 	gzipWriter := gzip.NewWriter(buf)
-	gzipWriter.Write(value)
-	gzipWriter.Close()
+	defer gzipWriter.Close()
+	if _, err := gzipWriter.Write(value); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	userData := base64.StdEncoding.EncodeToString(buf.Bytes())
 

--- a/pkg/cloud/helpers.go
+++ b/pkg/cloud/helpers.go
@@ -16,10 +16,25 @@ limitations under the License.
 
 package cloud
 
+import (
+	"bytes"
+	"compress/gzip"
+)
+
 type set func(string)
 
 func setIfNotEmpty(str string, setFn set) {
 	if str != "" {
 		setFn(str)
 	}
+}
+
+func CompressData(data []byte) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	gzipWriter := gzip.NewWriter(buf)
+	defer gzipWriter.Close()
+	if _, err := gzipWriter.Write(data); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
userData has a limit of 32KB (http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/4.8/virtual_machines/user-data.html)
When testing with two control planes, three etcd instances, and three worker nodes it failed to create the second control plane because the base64 encoded userData was over 32KB. However, CloudStack supports gzip compression for userData. To avoid too large userData we need to compress the userData using gzip before base64 encoding. 

*Testing performed:*
Manual tests performed. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->