### PR TITLE
Adding cluster webhook validation for control plane endpoint

### DIFF
--- a/api/v1alpha3/cloudstackcluster_webhook.go
+++ b/api/v1alpha3/cloudstackcluster_webhook.go
@@ -94,6 +94,8 @@ func (r *CloudStackCluster) ValidateUpdate(old runtime.Object) error {
 	// No spec fields may be changed
 	errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.Zone, oldSpec.Zone, "zone", errorList)
 	errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.Network, oldSpec.Network, "network", errorList)
+	errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.ControlPlaneEndpoint.Host, oldSpec.ControlPlaneEndpoint.Host, "controlplaneendpointhost", errorList)
+	errorList = webhook_utilities.EnsureStringFieldsAreEqual(string(spec.ControlPlaneEndpoint.Port), string(oldSpec.ControlPlaneEndpoint.Port), "controlplaneendpointport", errorList)
 	if spec.IdentityRef != nil && oldSpec.IdentityRef != nil {
 		errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.IdentityRef.Kind, oldSpec.IdentityRef.Kind, "identityRef.Kind", errorList)
 		errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.IdentityRef.Name, oldSpec.IdentityRef.Name, "identityRef.Name", errorList)

--- a/api/v1alpha3/cloudstackcluster_webhook_test.go
+++ b/api/v1alpha3/cloudstackcluster_webhook_test.go
@@ -156,6 +156,14 @@ var _ = Describe("CloudStackCluster webhooks", func() {
 				Expect(k8sClient.Update(ctx, cloudStackClusterUpdate).Error()).Should(MatchRegexp(forbiddenRegex, "network"))
 
 				cloudStackCluster.DeepCopyInto(cloudStackClusterUpdate)
+				cloudStackClusterUpdate.Spec.ControlPlaneEndpoint.Host = "1.1.1.1"
+				Expect(k8sClient.Update(ctx, cloudStackClusterUpdate).Error()).Should(MatchRegexp(forbiddenRegex, "controlplaneendpointhost"))
+
+				cloudStackCluster.DeepCopyInto(cloudStackClusterUpdate)
+				cloudStackClusterUpdate.Spec.ControlPlaneEndpoint.Port = 1234
+				Expect(k8sClient.Update(ctx, cloudStackClusterUpdate).Error()).Should(MatchRegexp(forbiddenRegex, "controlplaneendpointport"))
+
+				cloudStackCluster.DeepCopyInto(cloudStackClusterUpdate)
 				cloudStackClusterUpdate.Spec.IdentityRef.Kind = "ConfigMap"
 				Expect(k8sClient.Update(ctx, cloudStackClusterUpdate).Error()).Should(MatchRegexp(forbiddenRegex, "identityRef\\.Kind"))
 


### PR DESCRIPTION
*Issue #, if available:*
CTECH-118

*Description of changes:*
Adding a validation step in the cloudstack cluster webhook to ensure that the control plane endpoint hasn't been modified to address test case #12 from the open source testing

*Testing performed:*
`make build && make test` succeeded


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->