### PR TITLE
Updating repo to support v0.3 output artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ endif
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
-VERSION ?= v0.3.0
 
 # Allow overriding release-manifest generation destination directory
 RELEASE_DIR ?= out

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
-VERSION ?= v0.2.0
+VERSION ?= v0.3.0
 
 # Allow overriding release-manifest generation destination directory
 RELEASE_DIR ?= out

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,3 +12,6 @@ releaseSeries:
   - major: 0
     minor: 2
     contract: v1alpha3
+  - major: 0
+    minor: 3
+    contract: v1alpha3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding clusterctl support for a v0.3 release by modifying the the metadata.yaml contract. This will enable us to create a CAPC pre-release which we can use to test downstream integration.

Also removing the VERSION variable since it's not used in the Makefile

*Testing performed:*
make build succeeded

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->