### PR TITLE
Refactoring account/domain validation webhook logic

### DIFF
--- a/api/v1alpha3/cloudstackcluster_webhook.go
+++ b/api/v1alpha3/cloudstackcluster_webhook.go
@@ -62,7 +62,7 @@ func (r *CloudStackCluster) ValidateCreate() error {
 		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "identityRef", "kind"), "must be a Secret"))
 	}
 
-	if (r.Spec.Account == "") != (r.Spec.Domain == "") {
+	if (r.Spec.Account != "") && (r.Spec.Domain == "") {
 		errorList = append(errorList, field.Required(field.NewPath("spec", "account"), "account and domain must be specified together"))
 	}
 

--- a/api/v1alpha3/cloudstackcluster_webhook.go
+++ b/api/v1alpha3/cloudstackcluster_webhook.go
@@ -63,7 +63,7 @@ func (r *CloudStackCluster) ValidateCreate() error {
 	}
 
 	if (r.Spec.Account != "") && (r.Spec.Domain == "") {
-		errorList = append(errorList, field.Required(field.NewPath("spec", "account"), "account and domain must be specified together"))
+		errorList = append(errorList, field.Required(field.NewPath("spec", "account"), "specifying account requires additionally specifying domain"))
 	}
 
 	// Zone and Network are required fields


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As I understand, the criteria should be that if account is provided, then domain must be as well. Otherwise, domain is optional regardless of account. This PR attempts to modify the current logic to align with that. 

I encountered this issue after adding the "account" field and trying to spin up a cluster, only specifying domain (as I had been doing prior to this change)

*Testing performed:*
make build && make test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->