### PR TITLE
Bump timeout.

### DIFF
--- a/controllers/cloudstackcluster_controller_test.go
+++ b/controllers/cloudstackcluster_controller_test.go
@@ -66,7 +66,7 @@ func getCapiCluster() *clusterv1.Cluster {
 }
 
 const (
-	timeout = time.Second * 60
+	timeout = time.Second * 120
 )
 
 var _ = Describe("CloudStackClusterReconciler", func() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bumped timing to 120 seconds to prevent timeouts on slow hardware.

*Testing performed:*
Ran prow test 5 times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->