### PR TITLE
Exposing controller metrics on port 8080 on all IPs, a la CAPV.

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -29,6 +29,7 @@ patchesStrategicMerge:
 - manager_image_patch_edited.yaml
 - manager_webhook_patch.yaml
 - webhookcainjection_patch.yaml
+- manager_prometheus_metrics_patch.yaml
 
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics

--- a/config/default/manager_prometheus_metrics_patch.yaml
+++ b/config/default/manager_prometheus_metrics_patch.yaml
@@ -1,0 +1,19 @@
+# This patch enables Prometheus scraping for the manager pod.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      # Expose the prometheus metrics on default port
+      - name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func setFlags() *managerOpts {
 	flag.StringVar(
 		&opts.MetricsAddr,
 		"metrics-bind-addr",
-		":8080",
+		"localhost:8080",
 		"The address the metric endpoint binds to.")
 	flag.StringVar(
 		&opts.ProbeAddr,

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func setFlags() *managerOpts {
 	flag.StringVar(
 		&opts.MetricsAddr,
 		"metrics-bind-addr",
-		"localhost:8080",
+		":8080",
 		"The address the metric endpoint binds to.")
 	flag.StringVar(
 		&opts.ProbeAddr,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Exposing CAPC Controller Metrics port for direct access, a la CAPV (no kube-proxy, no Prometheus Operator ServiceMonitor CRD).


*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->