### PR TITLE
make base64 encode works for both macos and linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ pkg/mocks/mock%.go: $(shell find ./pkg/cloud -type f -name "*test*" -prune -o -p
 
 .PHONY: tilt-up 
 tilt-up: cluster-api kind-cluster cluster-api/tilt-settings.json manifests cloud-config # Setup and run tilt for development.
-	export CLOUDSTACK_B64ENCODED_SECRET=$$(base64 -i cloud-config) && cd cluster-api && tilt up
+	export CLOUDSTACK_B64ENCODED_SECRET=$(base64 -w0 -i cloud-config 2>/dev/null || base64 -b 0 -i cloud-config) && cd cluster-api && tilt up
 
 .PHONY: kind-cluster
 kind-cluster: cluster-api # Create a kind cluster with a local Docker repository.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Another container networking choice is to use [kindnet](https://github.com/aojea
     2. Run the following command to save the above cloudstack connection info into an environment variable, to be used by `./config/default/credentials.yaml` and ultimately the generated `infrastructure-components.yaml`, where it gets passed to CAPC:
 
         ```
-        export CLOUDSTACK_B64ENCODED_SECRET=$(base64 -i cloud-config)
+        export CLOUDSTACK_B64ENCODED_SECRET=$(base64 -w0 -i cloud-config 2>/dev/null || base64 -b 0 -i cloud-config)
         ```
 6. Set the IMG environment variable so that the Makefile knows where to push docker image (if building your own)
    1. `export IMG=localhost:5000/cluster-api-provider-capc`
@@ -142,7 +142,7 @@ Another container networking choice is to use [kindnet](https://github.com/aojea
 
 3. Generate the CAPC cluster spec yaml file
     ```
-    clusterctl generate cluster \
+    clusterctl generate cluster capc-cluster \
         --from ~/.cluster-api/overrides/infrastructure-cloudstack/<VERSION>/cluster-template.yaml \
         > capc-cluster-spec.yaml
     
@@ -171,7 +171,7 @@ Another container networking choice is to use [kindnet](https://github.com/aojea
     2. Run `KUBECONFIG=capc-cluster.kubeconfig cilium status` to confirm cilium status
 
 8. Verify the K8s cluster is fully up
-   1. Run `KUBECONFIG=capc-cluster.kubeconfig get nodes`, and observe the following output
+   1. Run `KUBECONFIG=capc-cluster.kubeconfig kubectl get nodes`, and observe the following output
    ```
    NAME                               STATUS   ROLES                  AGE     VERSION
    capc-cluster-control-plane-xsnxt   Ready    control-plane,master   2m56s   v1.20.10


### PR DESCRIPTION
*base64 uses different parameter for no breakline in macos and linux:*

*Description of changes:*
use fall-back in shell to make sure base64 encode without line break in both macos and linux.
*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->