### PR TITLE
Fix/add golint fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
   enable:
     - gosec
     - goheader
+    - revive
 
 run:
   issues-exit-code: 1

--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,9 @@ vet: ## Run go vet on the whole project.
 	go vet ./...
 
 .PHONY: lint
-lint: bin/golangci-lint bin/golint generate-mocks ## Run linting for the project.
+lint: bin/golangci-lint generate-mocks ## Run linting for the project.
 	go fmt ./...
 	go vet ./...
-	golint api/... controllers/... pkg/...
 	golangci-lint run -v --timeout 360s ./...
 	@ # The below string of commands checks that ginkgo isn't present in the controllers.
 	@(grep ginkgo ${PROJECT_DIR}/controllers/cloudstack*_controller.go && \
@@ -133,13 +132,11 @@ undeploy: bin/kustomize ## Undeploy controller from the K8s cluster specified in
 ##@ Binaries
 
 .PHONY: binaries
-binaries: bin/controller-gen bin/kustomize bin/ginkgo bin/golangci-lint bin/golint bin/mockgen bin/kubectl ## Locally install all needed bins.
+binaries: bin/controller-gen bin/kustomize bin/ginkgo bin/golangci-lint bin/mockgen bin/kubectl ## Locally install all needed bins.
 bin/controller-gen: ## Install controller-gen to bin.
 	GOBIN=$(PROJECT_DIR)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
 bin/golangci-lint: ## Install golangci-lint to bin.
 	GOBIN=$(PROJECT_DIR)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
-bin/golint: ## Install golint to bin.
-	GOBIN=$(PROJECT_DIR)/bin go install golang.org/x/lint/golint
 bin/ginkgo: ## Install ginkgo to bin.
 	GOBIN=$(PROJECT_DIR)/bin go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 bin/mockgen:

--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,10 @@ vet: ## Run go vet on the whole project.
 	go vet ./...
 
 .PHONY: lint
-lint: bin/golangci-lint ## Run linting for the project.
+lint: bin/golangci-lint bin/golint generate-mocks ## Run linting for the project.
 	go fmt ./...
 	go vet ./...
+	golint api/... controllers/... pkg/...
 	golangci-lint run -v --timeout 360s ./...
 	@ # The below string of commands checks that ginkgo isn't present in the controllers.
 	@(grep ginkgo ${PROJECT_DIR}/controllers/cloudstack*_controller.go && \
@@ -132,11 +133,13 @@ undeploy: bin/kustomize ## Undeploy controller from the K8s cluster specified in
 ##@ Binaries
 
 .PHONY: binaries
-binaries: bin/controller-gen bin/kustomize bin/ginkgo bin/golangci-lint bin/mockgen bin/kubectl ## Locally install all needed bins.
+binaries: bin/controller-gen bin/kustomize bin/ginkgo bin/golangci-lint bin/golint bin/mockgen bin/kubectl ## Locally install all needed bins.
 bin/controller-gen: ## Install controller-gen to bin.
 	GOBIN=$(PROJECT_DIR)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
 bin/golangci-lint: ## Install golangci-lint to bin.
 	GOBIN=$(PROJECT_DIR)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+bin/golint: ## Install golint to bin.
+	GOBIN=$(PROJECT_DIR)/bin go install golang.org/x/lint/golint
 bin/ginkgo: ## Install ginkgo to bin.
 	GOBIN=$(PROJECT_DIR)/bin go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 bin/mockgen:

--- a/api/v1beta1/cloudstackcluster_webhook.go
+++ b/api/v1beta1/cloudstackcluster_webhook.go
@@ -19,7 +19,7 @@ package v1beta1
 import (
 	"fmt"
 
-	"github.com/aws/cluster-api-provider-cloudstack/pkg/webhook_utilities"
+	"github.com/aws/cluster-api-provider-cloudstack/pkg/webhookutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -67,10 +67,10 @@ func (r *CloudStackCluster) ValidateCreate() error {
 	}
 
 	// Zone and Network are required fields
-	errorList = webhook_utilities.EnsureFieldExists(r.Spec.Zone, "Zone", errorList)
-	errorList = webhook_utilities.EnsureFieldExists(r.Spec.Network, "Network", errorList)
+	errorList = webhookutil.EnsureFieldExists(r.Spec.Zone, "Zone", errorList)
+	errorList = webhookutil.EnsureFieldExists(r.Spec.Network, "Network", errorList)
 
-	return webhook_utilities.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
+	return webhookutil.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -94,20 +94,20 @@ func (r *CloudStackCluster) ValidateUpdate(old runtime.Object) error {
 	}
 
 	// No spec fields may be changed
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.Zone, oldSpec.Zone, "zone", errorList)
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.Network, oldSpec.Network, "network", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(spec.Zone, oldSpec.Zone, "zone", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(spec.Network, oldSpec.Network, "network", errorList)
 	if oldSpec.ControlPlaneEndpoint.Host != "" { // Need to allow one time endpoint setting via CAPC cluster controller.
-		errorList = webhook_utilities.EnsureStringFieldsAreEqual(
+		errorList = webhookutil.EnsureStringFieldsAreEqual(
 			spec.ControlPlaneEndpoint.Host, oldSpec.ControlPlaneEndpoint.Host, "controlplaneendpointhost", errorList)
-		errorList = webhook_utilities.EnsureStringFieldsAreEqual(
+		errorList = webhookutil.EnsureStringFieldsAreEqual(
 			string(spec.ControlPlaneEndpoint.Port), string(oldSpec.ControlPlaneEndpoint.Port), "controlplaneendpointport", errorList)
 	}
 	if spec.IdentityRef != nil && oldSpec.IdentityRef != nil {
-		errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.IdentityRef.Kind, oldSpec.IdentityRef.Kind, "identityRef.Kind", errorList)
-		errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.IdentityRef.Name, oldSpec.IdentityRef.Name, "identityRef.Name", errorList)
+		errorList = webhookutil.EnsureStringFieldsAreEqual(spec.IdentityRef.Kind, oldSpec.IdentityRef.Kind, "identityRef.Kind", errorList)
+		errorList = webhookutil.EnsureStringFieldsAreEqual(spec.IdentityRef.Name, oldSpec.IdentityRef.Name, "identityRef.Name", errorList)
 	}
 
-	return webhook_utilities.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
+	return webhookutil.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1beta1/cloudstackcluster_webhook_test.go
+++ b/api/v1beta1/cloudstackcluster_webhook_test.go
@@ -31,7 +31,7 @@ var _ = Describe("CloudStackCluster webhooks", func() {
 		clusterKind        = "CloudStackCluster"
 		clusterName        = "test-cluster"
 		clusterNamespace   = "default"
-		clusterId          = "0"
+		clusterID          = "0"
 		identitySecretName = "IdentitySecret"
 		zone               = "Zone"
 		network            = "Network"
@@ -48,7 +48,7 @@ var _ = Describe("CloudStackCluster webhooks", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      clusterName,
 					Namespace: clusterNamespace,
-					UID:       clusterId,
+					UID:       clusterID,
 				},
 				Spec: CloudStackClusterSpec{
 					IdentityRef: &CloudStackIdentityReference{
@@ -74,7 +74,7 @@ var _ = Describe("CloudStackCluster webhooks", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      clusterName,
 					Namespace: clusterNamespace,
-					UID:       clusterId,
+					UID:       clusterID,
 				},
 				Spec: CloudStackClusterSpec{
 					IdentityRef: &CloudStackIdentityReference{
@@ -99,7 +99,7 @@ var _ = Describe("CloudStackCluster webhooks", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      clusterName,
 					Namespace: clusterNamespace,
-					UID:       clusterId,
+					UID:       clusterID,
 				},
 				Spec: CloudStackClusterSpec{
 					IdentityRef: &CloudStackIdentityReference{
@@ -129,7 +129,7 @@ var _ = Describe("CloudStackCluster webhooks", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      clusterName,
 					Namespace: clusterNamespace,
-					UID:       clusterId,
+					UID:       clusterID,
 				},
 				Spec: CloudStackClusterSpec{
 					IdentityRef: &CloudStackIdentityReference{

--- a/api/v1beta1/cloudstackmachine_webhook.go
+++ b/api/v1beta1/cloudstackmachine_webhook.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/aws/cluster-api-provider-cloudstack/pkg/webhook_utilities"
+	"github.com/aws/cluster-api-provider-cloudstack/pkg/webhookutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -63,10 +63,10 @@ func (r *CloudStackMachine) ValidateCreate() error {
 		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "identityRef", "kind"), "must be a Secret"))
 	}
 
-	errorList = webhook_utilities.EnsureFieldExists(r.Spec.Offering, "Offering", errorList)
-	errorList = webhook_utilities.EnsureFieldExists(r.Spec.Template, "Template", errorList)
+	errorList = webhookutil.EnsureFieldExists(r.Spec.Offering, "Offering", errorList)
+	errorList = webhookutil.EnsureFieldExists(r.Spec.Template, "Template", errorList)
 
-	return webhook_utilities.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
+	return webhookutil.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -81,23 +81,23 @@ func (r *CloudStackMachine) ValidateUpdate(old runtime.Object) error {
 	}
 	oldSpec := oldMachine.Spec
 
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(r.Spec.Offering, oldSpec.Offering, "offering", errorList)
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(r.Spec.SSHKey, oldSpec.SSHKey, "sshkey", errorList)
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(r.Spec.Template, oldSpec.Template, "template", errorList)
-	errorList = webhook_utilities.EnsureStringStringMapFieldsAreEqual(&r.Spec.Details, &oldSpec.Details, "details", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.Offering, oldSpec.Offering, "offering", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.SSHKey, oldSpec.SSHKey, "sshkey", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.Template, oldSpec.Template, "template", errorList)
+	errorList = webhookutil.EnsureStringStringMapFieldsAreEqual(&r.Spec.Details, &oldSpec.Details, "details", errorList)
 	if r.Spec.IdentityRef != nil && oldSpec.IdentityRef != nil {
-		errorList = webhook_utilities.EnsureStringFieldsAreEqual(
+		errorList = webhookutil.EnsureStringFieldsAreEqual(
 			r.Spec.IdentityRef.Kind, oldSpec.IdentityRef.Kind, "identityRef.Kind", errorList)
-		errorList = webhook_utilities.EnsureStringFieldsAreEqual(
+		errorList = webhookutil.EnsureStringFieldsAreEqual(
 			r.Spec.IdentityRef.Name, oldSpec.IdentityRef.Name, "identityRef.Name", errorList)
 	}
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(r.Spec.Affinity, oldSpec.Affinity, "affinity", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.Affinity, oldSpec.Affinity, "affinity", errorList)
 
 	if !reflect.DeepEqual(r.Spec.AffinityGroupIds, oldSpec.AffinityGroupIds) { // Equivalent to other Ensure funcs.
 		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "AffinityGroupIds"), "AffinityGroupIds"))
 	}
 
-	return webhook_utilities.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
+	return webhookutil.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1beta1/cloudstackmachinetemplate_webhook.go
+++ b/api/v1beta1/cloudstackmachinetemplate_webhook.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/aws/cluster-api-provider-cloudstack/pkg/webhook_utilities"
+	"github.com/aws/cluster-api-provider-cloudstack/pkg/webhookutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -76,10 +76,10 @@ func (r *CloudStackMachineTemplate) ValidateCreate() error {
 			"AffinityGroupIds cannot be specified when Affinity is specified as anything but `no`"))
 	}
 
-	errorList = webhook_utilities.EnsureFieldExists(spec.Offering, "Offering", errorList)
-	errorList = webhook_utilities.EnsureFieldExists(spec.Template, "Template", errorList)
+	errorList = webhookutil.EnsureFieldExists(spec.Offering, "Offering", errorList)
+	errorList = webhookutil.EnsureFieldExists(spec.Template, "Template", errorList)
 
-	return webhook_utilities.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
+	return webhookutil.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -97,25 +97,25 @@ func (r *CloudStackMachineTemplate) ValidateUpdate(old runtime.Object) error {
 	}
 	oldSpec := oldMachineTemplate.Spec.Spec.Spec
 
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.Offering, oldSpec.Offering, "offering", errorList)
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.SSHKey, oldSpec.SSHKey, "sshkey", errorList)
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.Template, oldSpec.Template, "template", errorList)
-	errorList = webhook_utilities.EnsureStringStringMapFieldsAreEqual(&spec.Details, &oldSpec.Details, "details", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(spec.Offering, oldSpec.Offering, "offering", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(spec.SSHKey, oldSpec.SSHKey, "sshkey", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(spec.Template, oldSpec.Template, "template", errorList)
+	errorList = webhookutil.EnsureStringStringMapFieldsAreEqual(&spec.Details, &oldSpec.Details, "details", errorList)
 
-	errorList = webhook_utilities.EnsureStringFieldsAreEqual(spec.Affinity, oldSpec.Affinity, "affinity", errorList)
+	errorList = webhookutil.EnsureStringFieldsAreEqual(spec.Affinity, oldSpec.Affinity, "affinity", errorList)
 
 	if !reflect.DeepEqual(spec.AffinityGroupIds, oldSpec.AffinityGroupIds) { // Equivalent to other Ensure funcs.
 		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "AffinityGroupIds"), "AffinityGroupIds"))
 	}
 
 	if spec.IdentityRef != nil && oldSpec.IdentityRef != nil {
-		errorList = webhook_utilities.EnsureStringFieldsAreEqual(
+		errorList = webhookutil.EnsureStringFieldsAreEqual(
 			spec.IdentityRef.Kind, oldSpec.IdentityRef.Kind, "identityRef.Kind", errorList)
-		errorList = webhook_utilities.EnsureStringFieldsAreEqual(
+		errorList = webhookutil.EnsureStringFieldsAreEqual(
 			spec.IdentityRef.Name, oldSpec.IdentityRef.Name, "identityRef.Name", errorList)
 	}
 
-	return webhook_utilities.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
+	return webhookutil.AggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, errorList)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// package v1beta1 contains API Schema definitions for the infrastructure v1beta1 API group
+// Package v1beta1 contains API Schema definitions for the infrastructure v1beta1 API group
 //+kubebuilder:object:generate=true
 //+groupName=infrastructure.cluster.x-k8s.io
 package v1beta1

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -45,6 +46,7 @@ webhooks:
     resources:
     - cloudstackmachines
   sideEffects: None
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/controllers/cloudstackcluster_controller.go
+++ b/controllers/cloudstackcluster_controller.go
@@ -94,17 +94,17 @@ func (r *CloudStackClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Setup patcher. This ensures modifications to the csCluster copy fetched above are patched into the origin.
-	if patchHelper, err := patch.NewHelper(csCluster, r.Client); err != nil {
+	patchHelper, err := patch.NewHelper(csCluster, r.Client)
+	if err != nil {
 		return ctrl.Result{}, err
-	} else {
-		defer func() {
-			if err = patchHelper.Patch(ctx, csCluster); err != nil {
-				msg := "error patching CloudStackCluster %s/%s"
-				err = errors.Wrapf(err, msg, csCluster.Namespace, csCluster.Name)
-				retErr = multierror.Append(retErr, err)
-			}
-		}()
 	}
+	defer func() {
+		if err = patchHelper.Patch(ctx, csCluster); err != nil {
+			msg := "error patching CloudStackCluster %s/%s"
+			err = errors.Wrapf(err, msg, csCluster.Namespace, csCluster.Name)
+			retErr = multierror.Append(retErr, err)
+		}
+	}()
 
 	// Delete Cluster Resources if deletion timestamp present.
 	if !csCluster.DeletionTimestamp.IsZero() {

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -30,8 +30,8 @@ import (
 	clientPkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetMachineSet attempts to fetch a MachineSet from CAPI machine owner reference.
-func GetMachineSetFromCAPIMachine(
+// getMachineSetFromCAPIMachine attempts to fetch a MachineSet from CAPI machine owner reference.
+func getMachineSetFromCAPIMachine(
 	ctx context.Context,
 	client clientPkg.Client,
 	capiMachine *capiv1.Machine,
@@ -58,8 +58,8 @@ func GetMachineSetFromCAPIMachine(
 	return nil, nil
 }
 
-// GetKubeadmControlPlaneFromCAPIMachine attempts to fetch a KubeadmControlPlane from a CAPI machine owner reference.
-func GetKubeadmControlPlaneFromCAPIMachine(
+// getKubeadmControlPlaneFromCAPIMachine attempts to fetch a KubeadmControlPlane from a CAPI machine owner reference.
+func getKubeadmControlPlaneFromCAPIMachine(
 	ctx context.Context,
 	client clientPkg.Client,
 	capiMachine *capiv1.Machine,
@@ -91,7 +91,7 @@ func IsOwnerDeleted(ctx context.Context, client clientPkg.Client, capiMachine *c
 	if util.IsControlPlaneMachine(capiMachine) {
 		// The controlplane sticks around after deletion pending the deletion of its machiens.
 		// As such, need to check the deletion timestamp thereof.
-		if cp, err := GetKubeadmControlPlaneFromCAPIMachine(ctx, client, capiMachine); cp != nil && cp.DeletionTimestamp == nil {
+		if cp, err := getKubeadmControlPlaneFromCAPIMachine(ctx, client, capiMachine); cp != nil && cp.DeletionTimestamp == nil {
 			return false, nil
 		} else if err != nil && !strings.Contains(err.Error(), "not found") {
 			return false, err
@@ -99,7 +99,7 @@ func IsOwnerDeleted(ctx context.Context, client clientPkg.Client, capiMachine *c
 	} else {
 		// The machineset is deleted immediately, regardless of machine ownership.
 		// It is sufficient to check for its existence.
-		if ms, err := GetMachineSetFromCAPIMachine(ctx, client, capiMachine); ms != nil {
+		if ms, err := getMachineSetFromCAPIMachine(ctx, client, capiMachine); ms != nil {
 			return false, nil
 		} else if err != nil && !strings.Contains(err.Error(), "not found") {
 			return false, err
@@ -122,7 +122,6 @@ func fetchOwnerRef(refList []meta.OwnerReference, kind string) *meta.OwnerRefere
 func GetManagementOwnerRef(capiMachine *capiv1.Machine) *meta.OwnerReference {
 	if util.IsControlPlaneMachine(capiMachine) {
 		return fetchOwnerRef(capiMachine.OwnerReferences, "KubeadmControlPlane")
-	} else {
-		return fetchOwnerRef(capiMachine.OwnerReferences, "MachineSet")
 	}
+	return fetchOwnerRef(capiMachine.OwnerReferences, "MachineSet")
 }

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -93,7 +93,7 @@ func IsOwnerDeleted(ctx context.Context, client clientPkg.Client, capiMachine *c
 		// As such, need to check the deletion timestamp thereof.
 		if cp, err := getKubeadmControlPlaneFromCAPIMachine(ctx, client, capiMachine); cp != nil && cp.DeletionTimestamp == nil {
 			return false, nil
-		} else if err != nil && !strings.Contains(err.Error(), "not found") {
+		} else if err != nil && !strings.Contains(strings.ToLower(err.Error()), "not found") {
 			return false, err
 		}
 	} else {
@@ -101,7 +101,7 @@ func IsOwnerDeleted(ctx context.Context, client clientPkg.Client, capiMachine *c
 		// It is sufficient to check for its existence.
 		if ms, err := getMachineSetFromCAPIMachine(ctx, client, capiMachine); ms != nil {
 			return false, nil
-		} else if err != nil && !strings.Contains(err.Error(), "not found") {
+		} else if err != nil && !strings.Contains(strings.ToLower(err.Error()), "not found") {
 			return false, err
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func main() {
 	// Setup CloudStack api client.
 	client, err := cloud.NewClient(opts.CloudConfigFile)
 	if err != nil {
-		if !strings.Contains(err.Error(), "Timeout") {
+		if !strings.Contains(strings.ToLower(err.Error()), "timeout") {
 			setupLog.Error(err, "unable to start manager")
 			os.Exit(1)
 		}

--- a/pkg/cloud/affinity_groups_test.go
+++ b/pkg/cloud/affinity_groups_test.go
@@ -67,13 +67,13 @@ var _ = Describe("AffinityGroup Unit Tests", func() {
 		Ω(client.GetOrCreateAffinityGroup(cluster, fakeAG)).Should(Succeed())
 	})
 	It("creates an affinity group", func() {
-		fakeAG.Id = "FakeID"
+		fakeAG.ID = "FakeID"
 		cluster.Spec.Account = "FakeAccount"
 		cluster.Status.DomainID = "FakeDomainId"
-		ags.EXPECT().GetAffinityGroupByID(fakeAG.Id).Return(nil, -1, errors.New("FakeError"))
+		ags.EXPECT().GetAffinityGroupByID(fakeAG.ID).Return(nil, -1, errors.New("fakeError"))
 		ags.EXPECT().NewCreateAffinityGroupParams(fakeAG.Name, fakeAG.Type).
 			Return(&cloudstack.CreateAffinityGroupParams{})
-		ags.EXPECT().CreateAffinityGroup(ParamMatch(And(AccountEquals("FakeAccount"), DomainIdEquals("FakeDomainId")))).
+		ags.EXPECT().CreateAffinityGroup(ParamMatch(And(AccountEquals("FakeAccount"), DomainIDEquals("FakeDomainId")))).
 			Return(&cloudstack.CreateAffinityGroupResponse{}, nil)
 
 		Ω(client.GetOrCreateAffinityGroup(cluster, fakeAG)).Should(Succeed())

--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -36,7 +36,7 @@ type Client interface {
 	ResolvePublicIPDetails(*infrav1.CloudStackCluster) (*cloudstack.PublicIpAddress, error)
 	ResolveLoadBalancerRuleDetails(*infrav1.CloudStackCluster) error
 	GetOrCreateLoadBalancerRule(*infrav1.CloudStackCluster) error
-	AffinityGroupIFace
+	AffinityGroupIface
 }
 
 type client struct {
@@ -47,27 +47,27 @@ type client struct {
 
 // cloud-config ini structure.
 type config struct {
-	ApiUrl    string `ini:"api-url"`
-	ApiKey    string `ini:"api-key"`
+	APIURL    string `ini:"api-url"`
+	APIKey    string `ini:"api-key"`
 	SecretKey string `ini:"secret-key"`
 	VerifySSL bool   `ini:"verify-ssl"`
 }
 
-func NewClient(cc_path string) (Client, error) {
+func NewClient(ccPath string) (Client, error) {
 	c := &client{}
 	cfg := &config{VerifySSL: true}
-	if rawCfg, err := ini.Load(cc_path); err != nil {
-		return nil, errors.Wrapf(err, "Error encountered while reading config at path: %s", cc_path)
+	if rawCfg, err := ini.Load(ccPath); err != nil {
+		return nil, errors.Wrapf(err, "error encountered while reading config at path: %s", ccPath)
 	} else if g := rawCfg.Section("Global"); len(g.Keys()) == 0 {
-		return nil, errors.New("Section Global not found.")
+		return nil, errors.New("section Global not found")
 	} else if err = rawCfg.Section("Global").StrictMapTo(cfg); err != nil {
-		return nil, errors.Wrapf(err, "Error encountered while parsing [Global] section from config at path: %s", cc_path)
+		return nil, errors.Wrapf(err, "error encountered while parsing [Global] section from config at path: %s", ccPath)
 	}
 
 	// This is a placeholder for sending non-blocking requests.
 	// c.csA = cloudstack.NewClient(apiUrl, apiKey, secretKey, false)
 	// TODO: attempt a less clunky client liveliness check (not just listing zones).
-	c.cs = cloudstack.NewAsyncClient(cfg.ApiUrl, cfg.ApiKey, cfg.SecretKey, cfg.VerifySSL)
+	c.cs = cloudstack.NewAsyncClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
 	_, err := c.cs.Zone.ListZones(c.cs.Zone.NewListZonesParams())
 	if err != nil && strings.Contains(err.Error(), "i/o timeout") {
 		return c, errors.Wrap(err, "Timeout while checking CloudStack API Client connectivity.")

--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -69,7 +69,7 @@ func NewClient(ccPath string) (Client, error) {
 	// TODO: attempt a less clunky client liveliness check (not just listing zones).
 	c.cs = cloudstack.NewAsyncClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
 	_, err := c.cs.Zone.ListZones(c.cs.Zone.NewListZonesParams())
-	if err != nil && strings.Contains(err.Error(), "i/o timeout") {
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "i/o timeout") {
 		return c, errors.Wrap(err, "Timeout while checking CloudStack API Client connectivity.")
 	}
 	return c, errors.Wrap(err, "Error encountered while checking CloudStack API Client connectivity.")

--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -37,7 +37,7 @@ type Client interface {
 	ResolveLoadBalancerRuleDetails(*infrav1.CloudStackCluster) error
 	GetOrCreateLoadBalancerRule(*infrav1.CloudStackCluster) error
 	AffinityGroupIface
-	TagIFace
+	TagIface
 }
 
 type client struct {

--- a/pkg/cloud/client_test.go
+++ b/pkg/cloud/client_test.go
@@ -26,7 +26,7 @@ import (
 
 // Example cloud-config ini structure.
 type Global struct {
-	ApiUrl    string `ini:"api-url"`
+	APIURL    string `ini:"api-url"`
 	VerifySSL bool   `ini:"verify-ssl"`
 }
 
@@ -53,7 +53,7 @@ var _ = Describe("Instance", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(rawCfg.Section("Global").MapTo(cfg)).Should(Succeed())
 			Ω(cfg.VerifySSL).Should(BeFalse())
-			Ω(cfg.ApiUrl).ShouldNot(BeEmpty())
+			Ω(cfg.APIURL).ShouldNot(BeEmpty())
 		})
 	})
 })

--- a/pkg/cloud/cluster.go
+++ b/pkg/cloud/cluster.go
@@ -79,7 +79,7 @@ func (c *client) GetOrCreateCluster(csCluster *infrav1.CloudStackCluster) (retEr
 			return retErr
 		}
 		if csCluster.Status.PublicIPID == "" { // Don't try to get public IP again it's already been fetched.
-			if retErr = c.AssociatePublicIpAddress(csCluster); retErr != nil {
+			if retErr = c.AssociatePublicIPAddress(csCluster); retErr != nil {
 				return retErr
 			}
 		}

--- a/pkg/cloud/helpers_test.go
+++ b/pkg/cloud/helpers_test.go
@@ -99,9 +99,9 @@ func (p paramMatcher) Matches(x interface{}) (retVal bool) {
 //
 //    Essentially it will generate a matcher that checks the value from p.Get<some field>() is Equal to an input String.
 //
-// 		DomainIdEquals = FieldMatcherGenerator("GetDomainid")
+// 		DomainIDEquals = FieldMatcherGenerator("GetDomainid")
 //      p := &CreateNewSomethingParams{Domainid: "FakeDomainId"}
-//      Ω(p).DomainIdEquals("FakeDomainId")
+//      Ω(p).DomainIDEquals("FakeDomainId")
 func FieldMatcherGenerator(fetchFunc string) func(string) types.GomegaMatcher {
 	return (func(expected string) types.GomegaMatcher {
 		return WithTransform(
@@ -114,6 +114,6 @@ func FieldMatcherGenerator(fetchFunc string) func(string) types.GomegaMatcher {
 }
 
 var (
-	DomainIdEquals = FieldMatcherGenerator("GetDomainid")
+	DomainIDEquals = FieldMatcherGenerator("GetDomainid")
 	AccountEquals  = FieldMatcherGenerator("GetAccount")
 )

--- a/pkg/cloud/helpers_test.go
+++ b/pkg/cloud/helpers_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Helpers", func() {
 			client, err := cloud.NewClient(filepath)
 
 			Ω(client).Should(BeNil())
-			Ω(err.Error()).Should(ContainSubstring("Section Global not found"))
+			Ω(err.Error()).Should(ContainSubstring("section Global not found"))
 		})
 	})
 

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -216,7 +216,7 @@ func (c *client) DestroyVMInstance(csMachine *infrav1.CloudStackMachine) error {
 	p := c.cs.VirtualMachine.NewDestroyVirtualMachineParams(*csMachine.Spec.InstanceID)
 	p.SetExpunge(true)
 	_, err := c.cs.VirtualMachine.DestroyVirtualMachine(p)
-	if err != nil && strings.Contains(err.Error(), "Unable to find UUID for id ") {
+	if err != nil && strings.Contains(err.Error(), "unable to find UUID for id ") {
 		// VM doesn't exist.  So the desired state is in effect.  Our work is done here.
 		return nil
 	}

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-const AntiAffinityValue = "anti"
+const antiAffinityValue = "anti"
 
 type VMIface interface {
 	GetOrCreateVMInstance(*infrav1.CloudStackMachine, *capiv1.Machine, *infrav1.CloudStackCluster, string) error
@@ -58,7 +58,7 @@ func (c *client) ResolveVMInstanceDetails(csMachine *infrav1.CloudStackMachine) 
 		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "no match found") {
 			return err
 		} else if count > 1 {
-			return fmt.Errorf("Found more than one VM Instance with ID %s.", *csMachine.Spec.InstanceID)
+			return fmt.Errorf("found more than one VM Instance with ID %s", *csMachine.Spec.InstanceID)
 		} else if err == nil {
 			setMachineDataFromVMMetrics(vmResp, csMachine)
 			return nil
@@ -71,7 +71,7 @@ func (c *client) ResolveVMInstanceDetails(csMachine *infrav1.CloudStackMachine) 
 		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "no match") {
 			return err
 		} else if count > 1 {
-			return fmt.Errorf("Found more than one VM Instance with name %s.", csMachine.Name)
+			return fmt.Errorf("found more than one VM Instance with name %s", csMachine.Name)
 		} else if err == nil {
 			setMachineDataFromVMMetrics(vmResp, csMachine)
 			return nil
@@ -170,7 +170,7 @@ func (c *client) GetOrCreateVMInstance(
 		p.SetAffinitygroupids(csMachine.Spec.AffinityGroupIds)
 	} else if strings.ToLower(csMachine.Spec.Affinity) != "no" && csMachine.Spec.Affinity != "" {
 		affinityType := AffinityGroupType
-		if strings.ToLower(csMachine.Spec.Affinity) == AntiAffinityValue {
+		if strings.ToLower(csMachine.Spec.Affinity) == antiAffinityValue {
 			affinityType = AntiAffinityGroupType
 		}
 		name, err := csMachine.AffinityGroupName(capiMachine)

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -160,11 +160,11 @@ func (c *client) GetOrCreateVMInstance(
 	setIfNotEmpty(csMachine.Name, p.SetDisplayname)
 	setIfNotEmpty(csMachine.Spec.SSHKey, p.SetKeypair)
 
-	if compressedAndEncodedUserData, err := CompressAndEncodeString(userData); err != nil {
+	compressedAndEncodedUserData, err := CompressAndEncodeString(userData)
+	if err != nil {
 		return err
-	} else {
-		setIfNotEmpty(compressedAndEncodedUserData, p.SetUserdata)
 	}
+	setIfNotEmpty(compressedAndEncodedUserData, p.SetUserdata)
 
 	if len(csMachine.Spec.AffinityGroupIds) > 0 {
 		p.SetAffinitygroupids(csMachine.Spec.AffinityGroupIds)
@@ -181,7 +181,7 @@ func (c *client) GetOrCreateVMInstance(
 		if err := c.GetOrCreateAffinityGroup(csCluster, group); err != nil {
 			return err
 		}
-		p.SetAffinitygroupids([]string{group.Id})
+		p.SetAffinitygroupids([]string{group.ID})
 	}
 	setIfNotEmpty(csCluster.Spec.Account, p.SetAccount)
 	setIfNotEmpty(csCluster.Status.DomainID, p.SetDomainid)

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -216,7 +216,7 @@ func (c *client) DestroyVMInstance(csMachine *infrav1.CloudStackMachine) error {
 	p := c.cs.VirtualMachine.NewDestroyVirtualMachineParams(*csMachine.Spec.InstanceID)
 	p.SetExpunge(true)
 	_, err := c.cs.VirtualMachine.DestroyVirtualMachine(p)
-	if err != nil && strings.Contains(err.Error(), "unable to find UUID for id ") {
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "unable to find UUID for id ") {
 		// VM doesn't exist.  So the desired state is in effect.  Our work is done here.
 		return nil
 	}

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Instance", func() {
 					Return(&cloudstack.VirtualMachinesMetric{}, 1, nil)
 				vms.EXPECT().NewDeployVirtualMachineParams(serviceOfferingID, templateID, csCluster.Status.ZoneID).
 					Return(&cloudstack.DeployVirtualMachineParams{})
-				vms.EXPECT().DeployVirtualMachine(ParamMatch(And(AccountEquals(account), DomainIdEquals(domainID)))).
+				vms.EXPECT().DeployVirtualMachine(ParamMatch(And(AccountEquals(account), DomainIDEquals(domainID)))).
 					Return(&cloudstack.DeployVirtualMachineResponse{Id: *csMachine.Spec.InstanceID}, nil)
 				vms.EXPECT().GetVirtualMachinesMetricByName(csMachine.Name).Return(nil, -1, notFoundError)
 

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Instance", func() {
 		It("Handles finding more than one VM instance by ID", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByID(*csMachine.Spec.InstanceID).Return(nil, 2, nil)
 			Ω(client.ResolveVMInstanceDetails(csMachine)).
-				Should(MatchError("Found more than one VM Instance with ID instance-id."))
+				Should(MatchError("found more than one VM Instance with ID instance-id"))
 		})
 
 		It("sets csMachine spec and status values when VM instance found by ID", func() {
@@ -105,7 +105,7 @@ var _ = Describe("Instance", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByName(csMachine.Name).Return(nil, 2, nil)
 
 			Ω(client.ResolveVMInstanceDetails(csMachine)).Should(
-				MatchError("Found more than one VM Instance with name instance-name."))
+				MatchError("found more than one VM Instance with name instance-name"))
 		})
 
 		It("sets csMachine spec and status values when VM instance found by Name", func() {

--- a/pkg/cloud/network.go
+++ b/pkg/cloud/network.go
@@ -61,7 +61,7 @@ func (c *client) ResolveNetwork(csCluster *infrav1.CloudStackCluster) (retErr er
 func (c *client) GetOrCreateNetwork(csCluster *infrav1.CloudStackCluster) (retErr error) {
 	if retErr = c.ResolveNetwork(csCluster); retErr == nil { // Found network.
 		return nil
-	} else if !strings.Contains(retErr.Error(), "No match found") { // Some other error.
+	} else if !strings.Contains(retErr.Error(), "no match found") { // Some other error.
 		return retErr
 	} // Network not found.
 
@@ -147,7 +147,7 @@ func (c *client) AssociatePublicIPAddress(csCluster *infrav1.CloudStackCluster) 
 func (c *client) OpenFirewallRules(csCluster *infrav1.CloudStackCluster) (retErr error) {
 	p := c.cs.Firewall.NewCreateEgressFirewallRuleParams(csCluster.Status.NetworkID, NetworkProtocolTCP)
 	_, retErr = c.cs.Firewall.CreateEgressFirewallRule(p)
-	if retErr != nil && strings.Contains(retErr.Error(), "There is already") { // Already a firewall rule here.
+	if retErr != nil && strings.Contains(retErr.Error(), "there is already") { // Already a firewall rule here.
 		retErr = nil
 	}
 	return retErr

--- a/pkg/cloud/network.go
+++ b/pkg/cloud/network.go
@@ -61,7 +61,7 @@ func (c *client) ResolveNetwork(csCluster *infrav1.CloudStackCluster) (retErr er
 func (c *client) GetOrCreateNetwork(csCluster *infrav1.CloudStackCluster) (retErr error) {
 	if retErr = c.ResolveNetwork(csCluster); retErr == nil { // Found network.
 		return nil
-	} else if !strings.Contains(retErr.Error(), "no match found") { // Some other error.
+	} else if !strings.Contains(strings.ToLower(retErr.Error()), "no match found") { // Some other error.
 		return retErr
 	} // Network not found.
 
@@ -147,7 +147,7 @@ func (c *client) AssociatePublicIPAddress(csCluster *infrav1.CloudStackCluster) 
 func (c *client) OpenFirewallRules(csCluster *infrav1.CloudStackCluster) (retErr error) {
 	p := c.cs.Firewall.NewCreateEgressFirewallRuleParams(csCluster.Status.NetworkID, NetworkProtocolTCP)
 	_, retErr = c.cs.Firewall.CreateEgressFirewallRule(p)
-	if retErr != nil && strings.Contains(retErr.Error(), "there is already") { // Already a firewall rule here.
+	if retErr != nil && strings.Contains(strings.ToLower(retErr.Error()), "there is already") { // Already a firewall rule here.
 		retErr = nil
 	}
 	return retErr
@@ -175,7 +175,7 @@ func (c *client) ResolveLoadBalancerRuleDetails(csCluster *infrav1.CloudStackClu
 func (c *client) GetOrCreateLoadBalancerRule(csCluster *infrav1.CloudStackCluster) (retErr error) {
 	// Check if rule exists.
 	if err := c.ResolveLoadBalancerRuleDetails(csCluster); err == nil ||
-		!strings.Contains(err.Error(), "no load balancer rule found") {
+		!strings.Contains(strings.ToLower(err.Error()), "no load balancer rule found") {
 		return err
 	}
 

--- a/pkg/cloud/network.go
+++ b/pkg/cloud/network.go
@@ -66,16 +66,16 @@ func (c *client) GetOrCreateNetwork(csCluster *infrav1.CloudStackCluster) (retEr
 	} // Network not found.
 
 	// Create network since it wasn't found.
-	offeringId, count, retErr := c.cs.NetworkOffering.GetNetworkOfferingID(NetOffering)
+	offeringID, count, retErr := c.cs.NetworkOffering.GetNetworkOfferingID(NetOffering)
 	if retErr != nil {
 		return retErr
 	} else if count != 1 {
-		return errors.New("found more than one network offering.")
+		return errors.New("found more than one network offering")
 	}
 	p := c.cs.Network.NewCreateNetworkParams(
 		csCluster.Spec.Network,
 		csCluster.Spec.Network,
-		offeringId,
+		offeringID,
 		csCluster.Status.ZoneID)
 	setIfNotEmpty(csCluster.Spec.Account, p.SetAccount)
 	setIfNotEmpty(csCluster.Status.DomainID, p.SetDomainid)
@@ -117,8 +117,8 @@ func (c *client) ResolvePublicIPDetails(csCluster *infrav1.CloudStackCluster) (*
 	return nil, errors.Errorf(`no public addresses found in network: "%s"`, csCluster.Spec.Network)
 }
 
-// AssociatePublicIpAddress Gets a PublicIP and associates it.
-func (c *client) AssociatePublicIpAddress(csCluster *infrav1.CloudStackCluster) (retErr error) {
+// AssociatePublicIPAddress Gets a PublicIP and associates it.
+func (c *client) AssociatePublicIPAddress(csCluster *infrav1.CloudStackCluster) (retErr error) {
 	publicAddress, err := c.ResolvePublicIPDetails(csCluster)
 	if err != nil {
 		return err

--- a/pkg/cloud/network_test.go
+++ b/pkg/cloud/network_test.go
@@ -41,11 +41,11 @@ var _ = Describe("Network", func() {
 	)
 
 	const (
-		fakeNetId           = "fakeNetID"
+		fakeNetID           = "fakeNetID"
 		fakeNetName         = "fakeNetName"
 		isolatedNetworkType = "Isolated"
-		lbRuleId            = "lbRuleID"
-		netId               = "someNetID"
+		lbRuleID            = "lbRuleID"
+		netID               = "someNetID"
 		protocol            = "tcp"
 		publicPort          = "6443"
 	)
@@ -77,44 +77,44 @@ var _ = Describe("Network", func() {
 
 	Context("for an existing network", func() {
 		It("resolves network details in cluster status", func() {
-			ns.EXPECT().GetNetworkID(fakeNetName).Return(fakeNetId, 1, nil)
-			ns.EXPECT().GetNetworkByID(fakeNetId).Return(&cloudstack.Network{Type: isolatedNetworkType}, 1, nil)
+			ns.EXPECT().GetNetworkID(fakeNetName).Return(fakeNetID, 1, nil)
+			ns.EXPECT().GetNetworkByID(fakeNetID).Return(&cloudstack.Network{Type: isolatedNetworkType}, 1, nil)
 			Ω(client.ResolveNetwork(csCluster)).Should(Succeed())
-			Ω(csCluster.Status.NetworkID).Should(Equal(fakeNetId))
+			Ω(csCluster.Status.NetworkID).Should(Equal(fakeNetID))
 			Ω(csCluster.Status.NetworkType).Should(Equal(isolatedNetworkType))
 		})
 
 		It("does not call to create a new network via GetOrCreateNetwork", func() {
-			ns.EXPECT().GetNetworkID(fakeNetName).Return(fakeNetId, 1, nil)
-			ns.EXPECT().GetNetworkByID(fakeNetId).Return(&cloudstack.Network{Type: isolatedNetworkType}, 1, nil)
+			ns.EXPECT().GetNetworkID(fakeNetName).Return(fakeNetID, 1, nil)
+			ns.EXPECT().GetNetworkByID(fakeNetID).Return(&cloudstack.Network{Type: isolatedNetworkType}, 1, nil)
 
 			Ω(client.GetOrCreateNetwork(csCluster)).Should(Succeed())
 		})
 
 		It("resolves network details with network ID instead of network name", func() {
-			ns.EXPECT().GetNetworkID(gomock.Any()).Return("", -1, errors.New("No match found for blah."))
-			ns.EXPECT().GetNetworkByID(fakeNetId).Return(&cloudstack.Network{Type: isolatedNetworkType}, 1, nil)
+			ns.EXPECT().GetNetworkID(gomock.Any()).Return("", -1, errors.New("no match found for blah"))
+			ns.EXPECT().GetNetworkByID(fakeNetID).Return(&cloudstack.Network{Type: isolatedNetworkType}, 1, nil)
 
-			csCluster.Spec.Network = fakeNetId
+			csCluster.Spec.Network = fakeNetID
 			Ω(client.GetOrCreateNetwork(csCluster)).Should(Succeed())
 		})
 	})
 
 	Context("for a non-existent network", func() {
 		It("when GetOrCreateNetwork is called it calls CloudStack to create a network", func() {
-			ns.EXPECT().GetNetworkID(gomock.Any()).Return("", -1, errors.New("No match found for blah."))
-			ns.EXPECT().GetNetworkByID(gomock.Any()).Return(nil, -1, errors.New("No match found for blah."))
+			ns.EXPECT().GetNetworkID(gomock.Any()).Return("", -1, errors.New("no match found for blah"))
+			ns.EXPECT().GetNetworkByID(gomock.Any()).Return(nil, -1, errors.New("no match found for blah"))
 			nos.EXPECT().GetNetworkOfferingID(gomock.Any()).Return("someOfferingID", 1, nil)
 			ns.EXPECT().NewCreateNetworkParams(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&cloudstack.CreateNetworkParams{})
-			ns.EXPECT().CreateNetwork(gomock.Any()).Return(&cloudstack.CreateNetworkResponse{Id: netId}, nil)
+			ns.EXPECT().CreateNetwork(gomock.Any()).Return(&cloudstack.CreateNetworkResponse{Id: netID}, nil)
 			Ω(client.GetOrCreateNetwork(csCluster)).Should(Succeed())
 		})
 	})
 
 	Context("for a closed firewall", func() {
 		It("OpenFirewallRule asks CloudStack to open the firewall", func() {
-			netID := netId
+			netID := netID
 			csCluster.Status.NetworkID = netID
 			fs.EXPECT().NewCreateEgressFirewallRuleParams(netID, protocol).
 				Return(&cloudstack.CreateEgressFirewallRuleParams{})
@@ -127,12 +127,12 @@ var _ = Describe("Network", func() {
 
 	Context("for an open firewall", func() {
 		It("OpenFirewallRule asks CloudStack to open the firewall anyway, but doesn't fail", func() {
-			netID := netId
+			netID := netID
 			csCluster.Status.NetworkID = netID
 			fs.EXPECT().NewCreateEgressFirewallRuleParams(netID, protocol).
 				Return(&cloudstack.CreateEgressFirewallRuleParams{})
 			fs.EXPECT().CreateEgressFirewallRule(&cloudstack.CreateEgressFirewallRuleParams{}).
-				Return(&cloudstack.CreateEgressFirewallRuleResponse{}, errors.New("There is already a rule like this."))
+				Return(&cloudstack.CreateEgressFirewallRuleResponse{}, errors.New("there is already a rule like this"))
 			Ω(client.OpenFirewallRules(csCluster)).Should(Succeed())
 		})
 	})
@@ -146,10 +146,10 @@ var _ = Describe("Network", func() {
 					Count:             1,
 					PublicIpAddresses: []*cloudstack.PublicIpAddress{{Id: "PublicIPID", Ipaddress: ipAddress}},
 				}, nil)
-			publicIpAddress, err := client.ResolvePublicIPDetails(csCluster)
+			publicIPAddress, err := client.ResolvePublicIPDetails(csCluster)
 			Ω(err).Should(Succeed())
-			Ω(publicIpAddress).ShouldNot(BeNil())
-			Ω(publicIpAddress.Ipaddress).Should(Equal(ipAddress))
+			Ω(publicIPAddress).ShouldNot(BeNil())
+			Ω(publicIPAddress.Ipaddress).Should(Equal(ipAddress))
 		})
 	})
 
@@ -158,18 +158,18 @@ var _ = Describe("Network", func() {
 			lbs.EXPECT().NewListLoadBalancerRulesParams().Return(&cloudstack.ListLoadBalancerRulesParams{})
 			lbs.EXPECT().ListLoadBalancerRules(gomock.Any()).Return(
 				&cloudstack.ListLoadBalancerRulesResponse{
-					LoadBalancerRules: []*cloudstack.LoadBalancerRule{{Publicport: publicPort, Id: lbRuleId}}}, nil)
+					LoadBalancerRules: []*cloudstack.LoadBalancerRule{{Publicport: publicPort, Id: lbRuleID}}}, nil)
 			Ω(client.ResolveLoadBalancerRuleDetails(csCluster)).Should(Succeed())
-			Ω(csCluster.Status.LBRuleID).Should(Equal(lbRuleId))
+			Ω(csCluster.Status.LBRuleID).Should(Equal(lbRuleID))
 		})
 
 		It("doesn't create a new load blancer rule on create", func() {
 			lbs.EXPECT().NewListLoadBalancerRulesParams().Return(&cloudstack.ListLoadBalancerRulesParams{})
 			lbs.EXPECT().ListLoadBalancerRules(gomock.Any()).
 				Return(&cloudstack.ListLoadBalancerRulesResponse{
-					LoadBalancerRules: []*cloudstack.LoadBalancerRule{{Publicport: publicPort, Id: lbRuleId}}}, nil)
+					LoadBalancerRules: []*cloudstack.LoadBalancerRule{{Publicport: publicPort, Id: lbRuleID}}}, nil)
 			Ω(client.GetOrCreateLoadBalancerRule(csCluster)).Should(Succeed())
-			Ω(csCluster.Status.LBRuleID).Should(Equal(lbRuleId))
+			Ω(csCluster.Status.LBRuleID).Should(Equal(lbRuleID))
 		})
 	})
 
@@ -177,14 +177,14 @@ var _ = Describe("Network", func() {
 		It("calls cloudstack to create a new load balancer rule.", func() {
 			lbs.EXPECT().NewListLoadBalancerRulesParams().Return(&cloudstack.ListLoadBalancerRulesParams{})
 			lbs.EXPECT().ListLoadBalancerRules(gomock.Any()).Return(&cloudstack.ListLoadBalancerRulesResponse{
-				LoadBalancerRules: []*cloudstack.LoadBalancerRule{{Publicport: "7443", Id: lbRuleId}}}, nil)
+				LoadBalancerRules: []*cloudstack.LoadBalancerRule{{Publicport: "7443", Id: lbRuleID}}}, nil)
 			lbs.EXPECT().NewCreateLoadBalancerRuleParams(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&cloudstack.CreateLoadBalancerRuleParams{})
-			const randomId = "randomID"
+			const randomID = "randomID"
 			lbs.EXPECT().CreateLoadBalancerRule(gomock.Any()).
-				Return(&cloudstack.CreateLoadBalancerRuleResponse{Id: randomId}, nil)
+				Return(&cloudstack.CreateLoadBalancerRuleResponse{Id: randomID}, nil)
 			Ω(client.GetOrCreateLoadBalancerRule(csCluster)).Should(Succeed())
-			Ω(csCluster.Status.LBRuleID).Should(Equal(randomId))
+			Ω(csCluster.Status.LBRuleID).Should(Equal(randomID))
 		})
 	})
 })

--- a/pkg/cloud/network_test.go
+++ b/pkg/cloud/network_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Network", func() {
 		It("does not call to create a new network via GetOrCreateNetwork", func() {
 			ns.EXPECT().GetNetworkID(fakeNetName).Return(fakeNetID, 1, nil)
 			ns.EXPECT().GetNetworkByID(fakeNetID).Return(&cloudstack.Network{Type: isolatedNetworkType}, 1, nil)
-			expectNetworkTags(fakeNetId)
+			expectNetworkTags(fakeNetID)
 
 			Ω(client.GetOrCreateNetwork(csCluster)).Should(Succeed())
 		})
@@ -111,7 +111,7 @@ var _ = Describe("Network", func() {
 		It("resolves network details with network ID instead of network name", func() {
 			ns.EXPECT().GetNetworkID(gomock.Any()).Return("", -1, errors.New("no match found for blah"))
 			ns.EXPECT().GetNetworkByID(fakeNetID).Return(&cloudstack.Network{Type: isolatedNetworkType}, 1, nil)
-			expectNetworkTags(fakeNetId)
+			expectNetworkTags(fakeNetID)
 
 			csCluster.Spec.Network = fakeNetID
 			Ω(client.GetOrCreateNetwork(csCluster)).Should(Succeed())
@@ -126,7 +126,7 @@ var _ = Describe("Network", func() {
 			ns.EXPECT().NewCreateNetworkParams(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&cloudstack.CreateNetworkParams{})
 			ns.EXPECT().CreateNetwork(gomock.Any()).Return(&cloudstack.CreateNetworkResponse{Id: netID}, nil)
-			expectNetworkTags(netId)
+			expectNetworkTags(netID)
 
 			Ω(client.GetOrCreateNetwork(csCluster)).Should(Succeed())
 		})

--- a/pkg/cloud/tags.go
+++ b/pkg/cloud/tags.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cloud/tags.go
+++ b/pkg/cloud/tags.go
@@ -29,31 +29,31 @@ const (
 )
 
 // TagNetwork adds tags to a network by network id.
-func (c *client) AddNetworkTags(networkId string, tags map[string]string) error {
-	p := c.cs.Resourcetags.NewCreateTagsParams([]string{networkId}, resourceTypeNetwork, tags)
+func (c *client) AddNetworkTags(networkID string, tags map[string]string) error {
+	p := c.cs.Resourcetags.NewCreateTagsParams([]string{networkID}, resourceTypeNetwork, tags)
 	_, err := c.cs.Resourcetags.CreateTags(p)
 	return err
 }
 
 // GetNetworkTags gets tags by network id.
-func (c *client) GetNetworkTags(networkId string) (map[string]string, error) {
+func (c *client) GetNetworkTags(networkID string) (map[string]string, error) {
 	p := c.cs.Resourcetags.NewListTagsParams()
-	p.SetResourceid(networkId)
+	p.SetResourceid(networkID)
 	p.SetResourcetype(resourceTypeNetwork)
-	if listTagResponse, err := c.cs.Resourcetags.ListTags(p); err != nil {
+	listTagResponse, err := c.cs.Resourcetags.ListTags(p)
+	if err != nil {
 		return nil, err
-	} else {
-		tags := make(map[string]string, listTagResponse.Count)
-		for _, t := range listTagResponse.Tags {
-			tags[t.Key] = t.Value
-		}
-		return tags, nil
 	}
+	tags := make(map[string]string, listTagResponse.Count)
+	for _, t := range listTagResponse.Tags {
+		tags[t.Key] = t.Value
+	}
+	return tags, nil
 }
 
 // DeleteNetworkTags deletes matching tags from a network
-func (c *client) DeleteNetworkTags(networkId string, tagsToDelete map[string]string) error {
-	p := c.cs.Resourcetags.NewDeleteTagsParams([]string{networkId}, resourceTypeNetwork)
+func (c *client) DeleteNetworkTags(networkID string, tagsToDelete map[string]string) error {
+	p := c.cs.Resourcetags.NewDeleteTagsParams([]string{networkID}, resourceTypeNetwork)
 	p.SetTags(tagsToDelete)
 	_, err := c.cs.Resourcetags.DeleteTags(p)
 	return err

--- a/pkg/cloud/tags.go
+++ b/pkg/cloud/tags.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package cloud
 
-type TagIFace interface {
+type TagIface interface {
 	AddNetworkTags(string, map[string]string) error
 	GetNetworkTags(string) (map[string]string, error)
 	DeleteNetworkTags(string, map[string]string) error

--- a/pkg/cloud/tags_test.go
+++ b/pkg/cloud/tags_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cloud/tags_test.go
+++ b/pkg/cloud/tags_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Tag Unit Tests", func() {
 		)
 
 		var (
-			networkId string
+			networkID string
 			testTags  map[string]string
 		)
 
@@ -62,25 +62,25 @@ var _ = Describe("Tag Unit Tests", func() {
 				Skip("Could not find network.")
 			}
 
-			networkId = cluster.Status.NetworkID
+			networkID = cluster.Status.NetworkID
 			testTags = map[string]string{tagKey: tagValue}
 		})
 
 		It("Tags a network with an arbitrary tag.", func() {
 			// Delete the tag if it already exists from a prior test run, otherwise the test will fail.
-			_ = client.DeleteNetworkTags(networkId, testTags)
-			Ω(client.AddNetworkTags(networkId, testTags)).Should(Succeed())
+			_ = client.DeleteNetworkTags(networkID, testTags)
+			Ω(client.AddNetworkTags(networkID, testTags)).Should(Succeed())
 		})
 
 		It("Fetches said tag.", func() {
-			tags, err := client.GetNetworkTags(networkId)
+			tags, err := client.GetNetworkTags(networkID)
 			Ω(err).Should(BeNil())
 			Ω(tags[tagKey]).Should(Equal(tagValue))
 		})
 
 		It("Deletes said tag.", func() {
-			Ω(client.DeleteNetworkTags(networkId, testTags)).Should(Succeed())
-			remainingTags, err := client.GetNetworkTags(networkId)
+			Ω(client.DeleteNetworkTags(networkID, testTags)).Should(Succeed())
+			remainingTags, err := client.GetNetworkTags(networkID)
 			Ω(err).Should(BeNil())
 			Ω(remainingTags[tagKey]).Should(Equal(""))
 		})

--- a/pkg/webhookutil/webhook_validators.go
+++ b/pkg/webhookutil/webhook_validators.go
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhook_utilities
+package webhookutil
 
 import (
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"reflect"
 )
 
 func EnsureFieldExists(value string, name string, allErrs field.ErrorList) field.ErrorList {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* https://goreportcard.com/report/github.com/aws/cluster-api-provider-cloudstack#golint reported lint errors. It seems goreportcard uses golint as linter. Added revive to the enabled linters in golangci settings because revive is a new name of golint, however, revive doesn't report golint warnings related to missing comments for exported consts and/or functions.

*Testing performed:*
'make test' passed
'deploy-app' e2e test passed.
All e2e tests passed. 
```
Ran 13 of 14 Specs in 5540.073 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 1 Skipped
PASS

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->