### PR TITLE
escape the $ in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ pkg/mocks/mock%.go: $(shell find ./pkg/cloud -type f -name "*test*" -prune -o -p
 
 .PHONY: tilt-up 
 tilt-up: cluster-api kind-cluster cluster-api/tilt-settings.json manifests cloud-config # Setup and run tilt for development.
-	export CLOUDSTACK_B64ENCODED_SECRET=$(base64 -w0 -i cloud-config 2>/dev/null || base64 -b 0 -i cloud-config) && cd cluster-api && tilt up
+	export CLOUDSTACK_B64ENCODED_SECRET=$$(base64 -w0 -i cloud-config 2>/dev/null || base64 -b 0 -i cloud-config) && cd cluster-api && tilt up
 
 .PHONY: kind-cluster
 kind-cluster: cluster-api # Create a kind cluster with a local Docker repository.


### PR DESCRIPTION
*dollar-sign needs to be escaped in Makefile:*

*Description of changes:*
Escape dollar sign in make file
*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->