### PR TITLE
Destroy VM asynchronously

### DIFF
--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -41,9 +41,8 @@ type Client interface {
 }
 
 type client struct {
-	cs *cloudstack.CloudStackClient
-	// This is a placeholder for sending non-blocking requests.
-	// csA *cloudstack.CloudStackClient
+	cs      *cloudstack.CloudStackClient
+	csAsync *cloudstack.CloudStackClient
 }
 
 // cloud-config ini structure.
@@ -65,11 +64,9 @@ func NewClient(ccPath string) (Client, error) {
 		return nil, errors.Wrapf(err, "error encountered while parsing [Global] section from config at path: %s", ccPath)
 	}
 
-	// This is a placeholder for sending non-blocking requests.
-	// c.csA = cloudstack.NewClient(apiUrl, apiKey, secretKey, false)
-	// TODO: attempt a less clunky client liveliness check (not just listing zones).
 	c.cs = cloudstack.NewAsyncClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
-	_, err := c.cs.Zone.ListZones(c.cs.Zone.NewListZonesParams())
+	c.csAsync = cloudstack.NewClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
+	_, err := c.cs.APIDiscovery.ListApis(c.cs.APIDiscovery.NewListApisParams())
 	if err != nil && strings.Contains(strings.ToLower(err.Error()), "i/o timeout") {
 		return c, errors.Wrap(err, "Timeout while checking CloudStack API Client connectivity.")
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently when deleting a cluster VM instances are deleted one by one. @rejoshed found that async client could be helpful when deleting VM instances in parallel. Here is the performance test results. Scaling down would take advantage of this change as well.

| Code      | Test | Time |
| ----------- | ----------- | ----------- |
| Original      | 1 CP + 2 Worker       |  9.5 min |
| Original      | 1 CP + 10 Worker       |  25 min |
| Original      | 9 CP + 10 Worker       |  +60 min |
| New      | 1 CP + 2 Worker       |  7.5 min |
| New      | 1 CP + 10 Worker       |  9.5 min |
| New      | 9 CP + 10 Worker       |  27 min |


*Testing performed:*
deploy-app test passed
deploy-app with 1 cp + 10 worker test passed
deploy-app with 9 cp + 10 worker test passed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->