### PR TITLE
To match node names to machine names, use CAPI machine names when creating CloudStack VMs

### DIFF
--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -156,8 +156,8 @@ func (c *client) GetOrCreateVMInstance(
 	// Create VM instance.
 	p := c.cs.VirtualMachine.NewDeployVirtualMachineParams(offeringID, templateID, csCluster.Status.ZoneID)
 	p.SetNetworkids([]string{csCluster.Status.NetworkID})
-	setIfNotEmpty(csMachine.Name, p.SetName)
-	setIfNotEmpty(csMachine.Name, p.SetDisplayname)
+	setIfNotEmpty(capiMachine.Name, p.SetName)
+	setIfNotEmpty(capiMachine.Name, p.SetDisplayname)
 	setIfNotEmpty(csMachine.Spec.SSHKey, p.SetKeypair)
 
 	compressedAndEncodedUserData, err := CompressAndEncodeString(userData)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The node names and the machine names don't match
```
 kubectl get machines -A -o wide
NAMESPACE     NAME                                  PROVIDERID                                           PHASE     VERSION              NODENAME
eksa-system   wonkun-cluster-etcd-lp9gx             cloudstack:///22955dfa-4a99-426a-978c-dd541ab90e6a   Running
eksa-system   wonkun-cluster-md-0-d44f56856-bq5tk   cloudstack:///7a238c32-1e36-4f89-9877-8d229ba6a41b   Running   v1.21.2-eks-1-21-6   wonkun-cluster-worker-node-template-1646162017279-kkzbn
eksa-system   wonkun-cluster-tccgb                  cloudstack:///c881a1b8-7b12-4d46-8505-f5cb83641744   Running   v1.21.2-eks-1-21-6   wonkun-cluster-control-plane-template-1646162017276-gpzr9
```
To fix this, I used CAPI machine names when creating CloudStack VMs instead of CloudStack machine names.

*Testing performed:*
I ran the deploy-app e2e test manually and it passed. And the node names match to the machine names. 
```
NAMESPACE           NAME                                     CLUSTER             NODENAME                                 PROVIDERID                                           PHASE     AGE     VERSION
deploy-app-g8j62z   deploy-app-e8agvw-control-plane-vqxl2    deploy-app-e8agvw   deploy-app-e8agvw-control-plane-vqxl2    cloudstack:///ed02b246-0004-4cac-813e-1c6262492106   Running   2m      v1.20.10
deploy-app-g8j62z   deploy-app-e8agvw-md-0-7d98cf548-4xbjh   deploy-app-e8agvw   deploy-app-e8agvw-md-0-7d98cf548-4xbjh   cloudstack:///1aab3b12-2dab-43bc-b2b7-aab24cae07d1   Running   2m32s   v1.20.10
deploy-app-g8j62z   deploy-app-e8agvw-md-0-7d98cf548-kn9kd   deploy-app-e8agvw   deploy-app-e8agvw-md-0-7d98cf548-kn9kd   cloudstack:///e54ef7d6-e6e2-4dde-b265-6eb4eff83574   Running   2m32s   v1.20.10

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->