### PR TITLE
Don't tag pre-existing networks or IP addresses

### DIFF
--- a/pkg/cloud/tags.go
+++ b/pkg/cloud/tags.go
@@ -51,6 +51,11 @@ func (c *client) AddClusterTag(resourceType ResourceType, resourceID string, csC
 		return err
 	}
 
+	// Don't tag resources unless they are now being created by CAPC, or were previously created by CAPC.
+	if !addCreatedByCAPCTag && existingTags[createdByCAPCTagName] == "" {
+		return nil
+	}
+
 	if existingTags[clusterTagName] == "" {
 		newTags[clusterTagName] = "1"
 	}

--- a/pkg/cloud/tags_test.go
+++ b/pkg/cloud/tags_test.go
@@ -76,9 +76,11 @@ var _ = Describe("Tag Unit Tests", func() {
 			if err != nil {
 				Fail("Failed to get existing tags. Error: " + err.Error())
 			}
-			err = client.DeleteTags(cloud.ResourceTypeNetwork, networkID, existingTags)
-			if err != nil {
-				Fail("Failed to delete existing tags. Error: " + err.Error())
+			if len(existingTags) > 0 {
+				err = client.DeleteTags(cloud.ResourceTypeNetwork, networkID, existingTags)
+				if err != nil {
+					Fail("Failed to delete existing tags. Error: " + err.Error())
+				}
 			}
 		})
 
@@ -116,14 +118,14 @@ var _ = Describe("Tag Unit Tests", func() {
 			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, networkID, csCluster, true)).Should(Succeed())
 		})
 
-		It("adds the tags for a cluster (resource NOT created by CAPC)", func() {
+		It("doesn't add the tags for a cluster (resource NOT created by CAPC)", func() {
 			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, networkID, csCluster, false)).Should(Succeed())
 
 			// Verify tags
 			tags, err := client.GetTags(cloud.ResourceTypeNetwork, networkID)
 			Ω(err).Should(BeNil())
 			Ω(tags[createdByCAPCTag]).Should(Equal(""))
-			Ω(tags[clusterTag]).Should(Equal("1"))
+			Ω(tags[clusterTag]).Should(Equal(""))
 		})
 
 		It("deletes a cluster tag", func() {


### PR DESCRIPTION
*Issue #, if available:* CTECH-184

*Description of changes:* Don't tag ACS resources that weren't created by CAPC

*Testing performed:* Manual testing and unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->