### PR TITLE
Call openFirewallRules in CreateIsolatedNetwork to create an egress rule

### DIFF
--- a/pkg/cloud/network.go
+++ b/pkg/cloud/network.go
@@ -30,7 +30,6 @@ type NetworkIface interface {
 	ResolveNetworkStatuses(*capcv1.CloudStackCluster) error
 	ResolveNetwork(*capcv1.CloudStackCluster, *capcv1.Network) error
 	CreateIsolatedNetwork(*capcv1.CloudStackCluster) error
-	OpenFirewallRules(*capcv1.CloudStackCluster) error
 	FetchPublicIP(*capcv1.CloudStackCluster) (*cloudstack.PublicIpAddress, error)
 	ResolveLoadBalancerRuleDetails(*capcv1.CloudStackCluster) error
 	GetOrCreateLoadBalancerRule(*capcv1.CloudStackCluster) error
@@ -143,6 +142,10 @@ func (c *client) CreateIsolatedNetwork(csCluster *capcv1.CloudStackCluster) (ret
 	csCluster.Status.Zones[zoneStatus.ID] = zoneStatus
 
 	if err := c.AddCreatedByCAPCTag(ResourceTypeNetwork, zoneStatus.Network.ID); err != nil {
+		return err
+	}
+
+	if err := c.openFirewallRules(zoneStatus.Network.ID); err != nil {
 		return err
 	}
 
@@ -268,8 +271,8 @@ func (c *client) AssociatePublicIPAddress(csCluster *capcv1.CloudStackCluster) (
 	return nil
 }
 
-func (c *client) OpenFirewallRules(csCluster *capcv1.CloudStackCluster) (retErr error) {
-	p := c.cs.Firewall.NewCreateEgressFirewallRuleParams(csCluster.Status.PublicIPNetworkID, NetworkProtocolTCP)
+func (c *client) openFirewallRules(networkID string) (retErr error) {
+	p := c.cs.Firewall.NewCreateEgressFirewallRuleParams(networkID, NetworkProtocolTCP)
 	_, retErr = c.cs.Firewall.CreateEgressFirewallRule(p)
 	if retErr != nil && strings.Contains(strings.ToLower(retErr.Error()), "there is already") { // Already a firewall rule here.
 		retErr = nil

--- a/pkg/cloud/network.go
+++ b/pkg/cloud/network.go
@@ -30,6 +30,7 @@ type NetworkIface interface {
 	ResolveNetworkStatuses(*capcv1.CloudStackCluster) error
 	ResolveNetwork(*capcv1.CloudStackCluster, *capcv1.Network) error
 	CreateIsolatedNetwork(*capcv1.CloudStackCluster) error
+	OpenFirewallRules(networkID string) error
 	FetchPublicIP(*capcv1.CloudStackCluster) (*cloudstack.PublicIpAddress, error)
 	ResolveLoadBalancerRuleDetails(*capcv1.CloudStackCluster) error
 	GetOrCreateLoadBalancerRule(*capcv1.CloudStackCluster) error
@@ -145,7 +146,7 @@ func (c *client) CreateIsolatedNetwork(csCluster *capcv1.CloudStackCluster) (ret
 		return err
 	}
 
-	if err := c.openFirewallRules(zoneStatus.Network.ID); err != nil {
+	if err := c.OpenFirewallRules(zoneStatus.Network.ID); err != nil {
 		return err
 	}
 
@@ -271,7 +272,7 @@ func (c *client) AssociatePublicIPAddress(csCluster *capcv1.CloudStackCluster) (
 	return nil
 }
 
-func (c *client) openFirewallRules(networkID string) (retErr error) {
+func (c *client) OpenFirewallRules(networkID string) (retErr error) {
 	p := c.cs.Firewall.NewCreateEgressFirewallRuleParams(networkID, NetworkProtocolTCP)
 	_, retErr = c.cs.Firewall.CreateEgressFirewallRule(p)
 	if retErr != nil && strings.Contains(strings.ToLower(retErr.Error()), "there is already") { // Already a firewall rule here.

--- a/pkg/cloud/network_test.go
+++ b/pkg/cloud/network_test.go
@@ -149,35 +149,6 @@ var _ = Describe("Network", func() {
 		Ω(client.GetOrCreateIsolatedNetwork(dummies.CSCluster)).Should(Succeed())
 	})
 
-	Context("for a closed firewall", func() {
-		It("OpenFirewallRule asks CloudStack to open the firewall", func() {
-			dummies.Zone1.Network = dummies.ISONet1
-			dummies.CSCluster.Status.Zones = capcv1.ZoneStatusMap{dummies.Zone1.ID: dummies.Zone1}
-			dummies.CSCluster.Status.PublicIPNetworkID = dummies.ISONet1.ID
-			fs.EXPECT().NewCreateEgressFirewallRuleParams(dummies.ISONet1.ID, cloud.NetworkProtocolTCP).
-				Return(&csapi.CreateEgressFirewallRuleParams{})
-			fs.EXPECT().CreateEgressFirewallRule(&csapi.CreateEgressFirewallRuleParams{}).
-				Return(&csapi.CreateEgressFirewallRuleResponse{}, nil)
-
-			Ω(client.OpenFirewallRules(dummies.CSCluster)).Should(Succeed())
-		})
-	})
-
-	Context("for an open firewall", func() {
-		It("OpenFirewallRule asks CloudStack to open the firewall anyway, but doesn't fail", func() {
-			dummies.Zone1.Network = dummies.ISONet1
-			dummies.CSCluster.Status.Zones = capcv1.ZoneStatusMap{dummies.Zone1.ID: dummies.Zone1}
-			dummies.CSCluster.Status.PublicIPNetworkID = dummies.ISONet1.ID
-
-			fs.EXPECT().NewCreateEgressFirewallRuleParams(dummies.ISONet1.ID, "tcp").
-				Return(&csapi.CreateEgressFirewallRuleParams{})
-			fs.EXPECT().CreateEgressFirewallRule(&csapi.CreateEgressFirewallRuleParams{}).
-				Return(&csapi.CreateEgressFirewallRuleResponse{}, errors.New("there is already a rule like this"))
-
-			Ω(client.OpenFirewallRules(dummies.CSCluster)).Should(Succeed())
-		})
-	})
-
 	Context("in an isolated network with public IPs available", func() {
 		It("will resolve public IP details given an endpoint spec", func() {
 			ipAddress := "192.168.1.14"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Resource cleanup e2e test fails because the VM instance created in the isolated network created by CAPC does not have an internet access. I found that there was no egress rule in the network and this is because of missed calling OpenFirewallRules function. 

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->