### PR TITLE
Fix misspells

### DIFF
--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -89,7 +89,7 @@ func getKubeadmControlPlaneFromCAPIMachine(
 // IsOwnerDeleted returns a boolean if the owner of the CAPI machine has been deleted.
 func IsOwnerDeleted(ctx context.Context, client clientPkg.Client, capiMachine *capiv1.Machine) (bool, error) {
 	if util.IsControlPlaneMachine(capiMachine) {
-		// The controlplane sticks around after deletion pending the deletion of its machiens.
+		// The controlplane sticks around after deletion pending the deletion of its machines.
 		// As such, need to check the deletion timestamp thereof.
 		if cp, err := getKubeadmControlPlaneFromCAPIMachine(ctx, client, capiMachine); cp != nil && cp.DeletionTimestamp == nil {
 			return false, nil

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -131,14 +131,14 @@ var _ = Describe("Instance", func() {
 				Should(MatchError(unknownErrorMessage))
 		})
 
-		It("returns errors occuring while fetching sevice offering information", func() {
+		It("returns errors occurring while fetching service offering information", func() {
 			expectVMNotFound()
 			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).Return("", -1, unknownError)
 			Ω(client.GetOrCreateVMInstance(dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, "")).
 				ShouldNot(Succeed())
 		})
 
-		It("returns errors if more than one sevice offering found", func() {
+		It("returns errors if more than one service offering found", func() {
 			expectVMNotFound()
 			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).Return("", 2, nil)
 			Ω(client.GetOrCreateVMInstance(dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, "")).

--- a/pkg/cloud/network.go
+++ b/pkg/cloud/network.go
@@ -257,7 +257,7 @@ func (c *client) AssociatePublicIPAddress(csCluster *capcv1.CloudStackCluster) (
 	setIfNotEmpty(csCluster.Status.DomainID, p.SetDomainid)
 	if _, err := c.cs.Address.AssociateIpAddress(p); err != nil {
 		return errors.Wrapf(err,
-			"error encountered while associating public IP address with ID: %s to netowrk with ID: %s",
+			"error encountered while associating public IP address with ID: %s to network with ID: %s",
 			publicAddress.Id, zoneStatus.Network.ID)
 	}
 	if err := c.AddClusterTag(ResourceTypeIPAddress, publicAddress.Id, csCluster); err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
goreportcard reported a few misspells. https://goreportcard.com/report/github.com/aws/cluster-api-provider-cloudstack#misspell

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->