### PR TITLE
Check the domain path always even if there is one domain returned.

### DIFF
--- a/pkg/cloud/cluster_test.go
+++ b/pkg/cloud/cluster_test.go
@@ -83,13 +83,69 @@ var _ = Describe("Cluster", func() {
 			as.EXPECT().NewListAccountsParams().Return(dummies.ListAccountsParams)
 			as.EXPECT().ListAccounts(dummies.ListAccountsParams).Return(dummies.ListAccountsResp, nil)
 			ns.EXPECT().GetNetworkByName(dummies.Net1.Name).Return(dummies.CAPCNetToCSAPINet(&dummies.Net1), 1, nil)
-
 			// Limit test to single zone.
 			dummies.CSCluster.Spec.Zones = []capcv1.Zone{dummies.Zone1}
 			dummies.CSCluster.Status.Zones = capcv1.ZoneStatusMap{}
 
 			Ω(client.GetOrCreateCluster(dummies.CSCluster)).Should(Succeed())
 			Ω(dummies.CSCluster.Status.DomainID).Should(Equal(dummies.DomainID))
+		})
+
+		It("resolves domain when ROOT domain is specified", func() {
+			zs.EXPECT().GetZoneID(dummies.Zone1.Name).Return(dummies.Zone1.ID, 1, nil)
+			zs.EXPECT().GetZoneByID(dummies.Zone1.ID).Return(dummies.CAPCZoneToCSAPIZone(&dummies.Zone1), 1, nil)
+			ds.EXPECT().NewListDomainsParams().Return(dummies.ListDomainsParams)
+			ds.EXPECT().ListDomains(dummies.ListDomainsParams).Return(dummies.ListDomainsResp, nil)
+			as.EXPECT().NewListAccountsParams().Return(dummies.ListAccountsParams)
+			as.EXPECT().ListAccounts(dummies.ListAccountsParams).Return(dummies.ListAccountsResp, nil)
+			ns.EXPECT().GetNetworkByName(dummies.Net1.Name).Return(dummies.CAPCNetToCSAPINet(&dummies.Net1), 1, nil)
+
+			// Limit test to single zone.
+			dummies.CSCluster.Spec.Zones = []capcv1.Zone{dummies.Zone1}
+			dummies.CSCluster.Status.Zones = capcv1.ZoneStatusMap{}
+
+			dummies.CSCluster.Spec.Domain = dummies.RootDomain
+
+			Ω(client.GetOrCreateCluster(dummies.CSCluster)).Should(Succeed())
+			Ω(dummies.CSCluster.Status.DomainID).Should(Equal(dummies.RootDomainID))
+		})
+
+		It("resolves domain when domain is a fully qualified name", func() {
+			zs.EXPECT().GetZoneID(dummies.Zone1.Name).Return(dummies.Zone1.ID, 1, nil)
+			zs.EXPECT().GetZoneByID(dummies.Zone1.ID).Return(dummies.CAPCZoneToCSAPIZone(&dummies.Zone1), 1, nil)
+			ds.EXPECT().NewListDomainsParams().Return(dummies.ListDomainsParams)
+			ds.EXPECT().ListDomains(dummies.ListDomainsParams).Return(dummies.ListDomainsResp, nil)
+			as.EXPECT().NewListAccountsParams().Return(dummies.ListAccountsParams)
+			as.EXPECT().ListAccounts(dummies.ListAccountsParams).Return(dummies.ListAccountsResp, nil)
+			ns.EXPECT().GetNetworkByName(dummies.Net1.Name).Return(dummies.CAPCNetToCSAPINet(&dummies.Net1), 1, nil)
+
+			// Limit test to single zone.
+			dummies.CSCluster.Spec.Zones = []capcv1.Zone{dummies.Zone1}
+			dummies.CSCluster.Status.Zones = capcv1.ZoneStatusMap{}
+
+			dummies.CSCluster.Spec.Domain = dummies.Level2Domain
+
+			Ω(client.GetOrCreateCluster(dummies.CSCluster)).Should(Succeed())
+			Ω(dummies.CSCluster.Status.DomainID).Should(Equal(dummies.Level2DomainID))
+		})
+
+		It("fails to resolve domain when domain path does not match", func() {
+			zs.EXPECT().GetZoneID(dummies.Zone1.Name).Return(dummies.Zone1.ID, 1, nil)
+			zs.EXPECT().GetZoneByID(dummies.Zone1.ID).Return(dummies.CAPCZoneToCSAPIZone(&dummies.Zone1), 1, nil)
+			ds.EXPECT().NewListDomainsParams().Return(dummies.ListDomainsParams)
+			ds.EXPECT().ListDomains(dummies.ListDomainsParams).Return(dummies.ListDomainsResp, nil)
+			as.EXPECT().NewListAccountsParams().Return(dummies.ListAccountsParams)
+			as.EXPECT().ListAccounts(dummies.ListAccountsParams).Return(dummies.ListAccountsResp, nil)
+			ns.EXPECT().GetNetworkByName(dummies.Net1.Name).Return(dummies.CAPCNetToCSAPINet(&dummies.Net1), 1, nil)
+
+			// Limit test to single zone.
+			dummies.CSCluster.Spec.Zones = []capcv1.Zone{dummies.Zone1}
+			dummies.CSCluster.Status.Zones = capcv1.ZoneStatusMap{}
+
+			dummies.CSCluster.Spec.Domain = dummies.Level2Domain
+
+			Ω(client.GetOrCreateCluster(dummies.CSCluster)).Should(Succeed())
+			Ω(dummies.CSCluster.Status.DomainID).Should(Equal(dummies.Level2DomainID))
 		})
 
 		It("resolves domain and account when none are specified", func() {

--- a/test/dummies/vars.go
+++ b/test/dummies/vars.go
@@ -25,6 +25,10 @@ var ( // Declare exported dummy vars.
 	ISONet1            capcv1.Network
 	Domain             string
 	DomainID           string
+	RootDomain         string
+	RootDomainID       string
+	Level2Domain       string
+	Level2DomainID     string
 	Account            string
 	Tags               map[string]string
 	Tag1               map[string]string
@@ -168,8 +172,12 @@ func SetDummyCSMachineVars() {
 // SetDummyCAPCClusterVars resets the values in each of the exported CloudStackCluster related dummy variables.
 // It is intended to be called in BeforeEach() functions.
 func SetDummyCAPCClusterVars() {
-	DomainID = "FakeDomainID"
 	Domain = "FakeDomainName"
+	DomainID = "FakeDomainID"
+	Level2Domain = "foo/FakeDomainName"
+	Level2DomainID = "FakeLevel2DomainID"
+	RootDomain = "ROOT"
+	RootDomainID = "FakeRootDomainID"
 	Account = "FakeAccountName"
 	CSApiVersion = "infrastructure.cluster.x-k8s.io/v1beta1"
 	CSClusterKind = "CloudStackCluster"
@@ -271,7 +279,7 @@ func SetDummyCSApiResponse() {
 	ListDomainsParams = &csapi.ListDomainsParams{}
 	ListDomainsResp = &csapi.ListDomainsResponse{}
 	ListDomainsResp.Count = 1
-	ListDomainsResp.Domains = []*csapi.Domain{{Id: DomainID}}
+	ListDomainsResp.Domains = []*csapi.Domain{{Id: DomainID, Path: "ROOT/" + Domain}, {Id: RootDomainID, Path: "ROOT"}, {Id: Level2DomainID, Path: "ROOT/" + Level2Domain}}
 
 	ListAccountsParams = &csapi.ListAccountsParams{}
 	ListAccountsResp = &csapi.ListAccountsResponse{}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, when a single domain is returned for the specified domain name it is returned without checking the domain path. Now, the domain path has to match. 

*Testing performed:*
Unit testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->