### PR TITLE
Annotations for affinity group naming.

### DIFF
--- a/api/v1beta1/cloudstackmachine_types.go
+++ b/api/v1beta1/cloudstackmachine_types.go
@@ -136,6 +136,11 @@ func (csm CloudStackMachine) AffinityGroupName(
 	return fmt.Sprintf("%sAffinity-%s-%s", strings.Title(csm.Spec.Affinity), managerOwnerRef.Name, managerOwnerRef.UID), nil
 }
 
+// The computed affinity group name relevant to this machine.
+func (csm CloudStackMachine) HasAffinityManaged() bool {
+	return csm.Spec.Affinity == "anti" || csm.Spec.Affinity == "pro"
+}
+
 //+kubebuilder:object:root=true
 
 // CloudStackMachineList contains a list of CloudStackMachine

--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -228,13 +228,13 @@ func (r *CloudStackMachineReconciler) reconcile(
 
 	if csMachine.HasAffinityManaged() {
 		// Store Affinity Group name.
-		if name, err := csMachine.AffinityGroupName(capiMachine); err != nil {
+		name, err := csMachine.AffinityGroupName(capiMachine)
+		if err != nil {
 			return ctrl.Result{}, errors.Wrap(
 				err, "error encountered when fetching managed affinity group name to annotate CloudStackMachine")
-		} else {
-			if _, set := csMachine.Annotations[AffinityNameAnnotationKey]; !set {
-				csMachine.Annotations[AffinityNameAnnotationKey] = name
-			}
+		}
+		if _, set := csMachine.Annotations[AffinityNameAnnotationKey]; !set {
+			csMachine.Annotations[AffinityNameAnnotationKey] = name
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:* CTECH-208

*Description of changes:*
Stores affinity group name in a CloudStackMachine annotation.

Also doesn't attempt to delete an affinity group unless the machine has managed affinity.


*Testing performed:*
Created and deleted a cluster. 

Struggling to do a clusterctl create/move/delete as I am encountering the following issue:
```
Error: failed to read "metadata.yaml" from the repository for provider "cluster-api": failed to get GitHub release v1.1.99: failed to read release "v1.1.99": GET https://api.github.com/repos/kubernetes-sigs/cluster-api/releases/tags/v1.1.99: 404 Not Found []
```
I will attempt to surmount this issue in the morning. Sigh...


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->