### PR TITLE
Use list affinity groups instead of get affinity group by ID or name to support sub-domain

### DIFF
--- a/pkg/cloud/affinity_groups_test.go
+++ b/pkg/cloud/affinity_groups_test.go
@@ -50,14 +50,17 @@ var _ = Describe("AffinityGroup Unit Tests", func() {
 
 	It("fetches an affinity group", func() {
 		dummies.AffinityGroup.ID = "" // Force name fetching.
-		ags.EXPECT().GetAffinityGroupByName(dummies.AffinityGroup.Name).Return(&cloudstack.AffinityGroup{}, 1, nil)
+		ags.EXPECT().NewListAffinityGroupsParams().Return(dummies.ListAffinityGroupsParams)
+		ags.EXPECT().ListAffinityGroups(dummies.ListAffinityGroupsParams).Return(dummies.ListAffinityGroupsResponse, nil)
 
 		Ω(client.GetOrCreateAffinityGroup(dummies.CSCluster, dummies.AffinityGroup)).Should(Succeed())
 	})
 	It("creates an affinity group", func() {
 		dummies.SetDummyDomainAndAccount()
 		dummies.SetDummyDomainID()
-		ags.EXPECT().GetAffinityGroupByID(dummies.AffinityGroup.ID).Return(nil, -1, errors.New("FakeError"))
+
+		ags.EXPECT().NewListAffinityGroupsParams().Return(dummies.ListAffinityGroupsParams)
+		ags.EXPECT().ListAffinityGroups(dummies.ListAffinityGroupsParams).Return(nil, errors.New("FakeError"))
 		ags.EXPECT().NewCreateAffinityGroupParams(dummies.AffinityGroup.Name, dummies.AffinityGroup.Type).
 			Return(&cloudstack.CreateAffinityGroupParams{})
 		ags.EXPECT().CreateAffinityGroup(ParamMatch(
@@ -95,7 +98,7 @@ var _ = Describe("AffinityGroup Unit Tests", func() {
 		})
 		It("Deletes an affinity group.", func() {
 			Ω(client.DeleteAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
-			Ω(client.FetchAffinityGroup(dummies.AffinityGroup)).ShouldNot(Succeed())
+			Ω(client.FetchAffinityGroup(dummies.CSCluster, dummies.AffinityGroup)).ShouldNot(Succeed())
 		})
 	})
 })

--- a/test/dummies/vars.go
+++ b/test/dummies/vars.go
@@ -12,49 +12,51 @@ import (
 )
 
 var ( // Declare exported dummy vars.
-	AffinityGroup      *cloud.AffinityGroup
-	CSCluster          *capcv1.CloudStackCluster
-	CAPIMachine        *capiv1.Machine
-	CSMachine1         *capcv1.CloudStackMachine
-	CAPICluster        *clusterv1.Cluster
-	CSMachineTemplate1 *capcv1.CloudStackMachineTemplate
-	Zone1              capcv1.Zone
-	Zone2              capcv1.Zone
-	Net1               capcv1.Network
-	Net2               capcv1.Network
-	ISONet1            capcv1.Network
-	Domain             string
-	DomainID           string
-	RootDomain         string
-	RootDomainID       string
-	Level2Domain       string
-	Level2DomainID     string
-	Account            string
-	Tags               map[string]string
-	Tag1               map[string]string
-	Tag2               map[string]string
-	Tag1Key            string
-	Tag1Val            string
-	Tag2Key            string
-	Tag2Val            string
-	CSApiVersion       string
-	CSClusterKind      string
-	CSClusterName      string
-	CSlusterNamespace  string
-	TestTags           map[string]string
-	CSClusterTagKey    string
-	CSClusterTagVal    string
-	CSClusterTag       map[string]string
-	CreatedByCapcKey   string
-	CreatedByCapcVal   string
-	LBRuleID           string
-	PublicIPID         string
-	EndPointHost       string
-	EndPointPort       int32
-	ListDomainsParams  *csapi.ListDomainsParams
-	ListDomainsResp    *csapi.ListDomainsResponse
-	ListAccountsParams *csapi.ListAccountsParams
-	ListAccountsResp   *csapi.ListAccountsResponse
+	AffinityGroup              *cloud.AffinityGroup
+	ListAffinityGroupsParams   *csapi.ListAffinityGroupsParams
+	ListAffinityGroupsResponse *csapi.ListAffinityGroupsResponse
+	CSCluster                  *capcv1.CloudStackCluster
+	CAPIMachine                *capiv1.Machine
+	CSMachine1                 *capcv1.CloudStackMachine
+	CAPICluster                *clusterv1.Cluster
+	CSMachineTemplate1         *capcv1.CloudStackMachineTemplate
+	Zone1                      capcv1.Zone
+	Zone2                      capcv1.Zone
+	Net1                       capcv1.Network
+	Net2                       capcv1.Network
+	ISONet1                    capcv1.Network
+	Domain                     string
+	DomainID                   string
+	RootDomain                 string
+	RootDomainID               string
+	Level2Domain               string
+	Level2DomainID             string
+	Account                    string
+	Tags                       map[string]string
+	Tag1                       map[string]string
+	Tag2                       map[string]string
+	Tag1Key                    string
+	Tag1Val                    string
+	Tag2Key                    string
+	Tag2Val                    string
+	CSApiVersion               string
+	CSClusterKind              string
+	CSClusterName              string
+	CSlusterNamespace          string
+	TestTags                   map[string]string
+	CSClusterTagKey            string
+	CSClusterTagVal            string
+	CSClusterTag               map[string]string
+	CreatedByCapcKey           string
+	CreatedByCapcVal           string
+	LBRuleID                   string
+	PublicIPID                 string
+	EndPointHost               string
+	EndPointPort               int32
+	ListDomainsParams          *csapi.ListDomainsParams
+	ListDomainsResp            *csapi.ListDomainsResponse
+	ListAccountsParams         *csapi.ListAccountsParams
+	ListAccountsResp           *csapi.ListAccountsResponse
 )
 
 // SetDummyVars sets/resets all dummy vars.
@@ -285,4 +287,9 @@ func SetDummyCSApiResponse() {
 	ListAccountsResp = &csapi.ListAccountsResponse{}
 	ListAccountsResp.Count = 1
 	ListAccountsResp.Accounts = []*csapi.Account{{Name: Account}}
+
+	ListAffinityGroupsParams = &csapi.ListAffinityGroupsParams{}
+	ListAffinityGroupsResponse = &csapi.ListAffinityGroupsResponse{}
+	ListAffinityGroupsResponse.Count = 1
+	ListAffinityGroupsResponse.AffinityGroups = []*csapi.AffinityGroup{{Name: AffinityGroup.Name, Id: AffinityGroup.ID}}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When create a cluster in a sub-domain with managed affinity group there is an error like this
```
Unable to create affinity group, a group with name ProAffinity-wonkun-management-cluster-7adbe2af-0e59-494b-8c92-cf0f980f2bb6 already exists
```
To fix this, list affinity groups should be used instead of get by ID or name. 

However, this PR does not make this happen because the ACS complains the following error when deploying a VM in a sub-domain with an affinity group created in the sub-domain. 

```
Acct[2e417bec-f13e-4994-9b5e-2d717fd91353-wonkun-admin] does not have permission to operate with resource AffinityGroup
```

*Testing performed:*
Manual testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->