### PR TITLE
Increase memory request and limit to 50Mi and 100Mi respectively

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,9 +41,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the management cluster, the capc memory usage starts from 16~21Mi without having any workload clusters. Therefore, 20Mi resource request is too tight so I am increasing it to 50Mi/100Mi. Here are the memory usage trend per the number of workload clusters. I couldn't find an increasing trend of the memory usage per the # of clusters. 

*Testing performed:*

1. 1-1-1 workload clusters

| # of WL      | Memory |
| ----------- | ----------- |
| 0      | 16Mi       |
| 1   | 19Mi       |
| 2   | 20Mi       |
| 3   | 20Mi       |
| 4  | 21Mi       |
| 5 | 20Mi       |
| 6  | 21Mi       |

2. 3-3-3 workload clusters

| # of WL      | Memory |
| ----------- | ----------- |
| 0      | 21Mi       |
| 1   | 22Mi       |
| 2   | 22Mi       |
| 3   | 22Mi       |
| 4  | 21Mi       |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->