### PR TITLE
Adding support for deletion when a VM is detected as expunging

### DIFF
--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -58,8 +58,8 @@ func NewClient(ccPath string) (Client, error) {
 		return nil, errors.Wrapf(err, "error encountered while parsing [Global] section from config at path: %s", ccPath)
 	}
 
-	c.cs = cloudstack.NewAsyncClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
-	c.csAsync = cloudstack.NewClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
+	c.csAsync = cloudstack.NewAsyncClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
+	c.cs = cloudstack.NewClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
 	_, err := c.cs.APIDiscovery.ListApis(c.cs.APIDiscovery.NewListApisParams())
 	if err != nil && strings.Contains(strings.ToLower(err.Error()), "i/o timeout") {
 		return c, errors.Wrap(err, "timeout while checking CloudStack API Client connectivity")
@@ -68,6 +68,6 @@ func NewClient(ccPath string) (Client, error) {
 }
 
 func NewClientFromCSAPIClient(cs *cloudstack.CloudStackClient) Client {
-	c := &client{cs: cs}
+	c := &client{cs: cs, csAsync: cs}
 	return c
 }

--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -58,8 +58,12 @@ func NewClient(ccPath string) (Client, error) {
 		return nil, errors.Wrapf(err, "error encountered while parsing [Global] section from config at path: %s", ccPath)
 	}
 
-	c.csAsync = cloudstack.NewAsyncClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
-	c.cs = cloudstack.NewClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
+	// The client returned from NewAsyncClient works in a synchronous way. On the other hand,
+	// a client returned from NewClient works in an asynchronous way. Dive into the constructor definition
+	// comments for more details
+	c.cs = cloudstack.NewAsyncClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
+	c.csAsync = cloudstack.NewClient(cfg.APIURL, cfg.APIKey, cfg.SecretKey, cfg.VerifySSL)
+	
 	_, err := c.cs.APIDiscovery.ListApis(c.cs.APIDiscovery.NewListApisParams())
 	if err != nil && strings.Contains(strings.ToLower(err.Error()), "i/o timeout") {
 		return c, errors.Wrap(err, "timeout while checking CloudStack API Client connectivity")

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -18,7 +18,6 @@ package cloud
 
 import (
 	"fmt"
-
 	"strings"
 
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -239,5 +238,18 @@ func (c *client) DestroyVMInstance(csMachine *infrav1.CloudStackMachine) error {
 	} else if err != nil {
 		return err
 	}
+
+	if err := c.ResolveVMInstanceDetails(csMachine); err == nil && csMachine.Status.InstanceState == "Expunging" ||
+		csMachine.Status.InstanceState == "Expunged" {
+		// VM is stopped and getting expunged.  So the desired state is getting satisfied.  Let's move on.
+		return nil
+	} else if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no match found") {
+			// VM doesn't exist.  So the desired state is in effect.  Our work is done here.
+			return nil
+		}
+		return err
+	}
+
 	return errors.New("VM deletion in progress")
 }

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -239,8 +239,8 @@ func (c *client) DestroyVMInstance(csMachine *infrav1.CloudStackMachine) error {
 		return err
 	}
 
-	if err := c.ResolveVMInstanceDetails(csMachine); err == nil && csMachine.Status.InstanceState == "Expunging" ||
-		csMachine.Status.InstanceState == "Expunged" {
+	if err := c.ResolveVMInstanceDetails(csMachine); err == nil && (csMachine.Status.InstanceState == "Expunging" ||
+		csMachine.Status.InstanceState == "Expunged") {
 		// VM is stopped and getting expunged.  So the desired state is getting satisfied.  Let's move on.
 		return nil
 	} else if err != nil {

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -362,7 +362,19 @@ var _ = Describe("Instance", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID).
 				Return(&cloudstack.VirtualMachinesMetric{
 					State: "Expunging",
-			}, 1, nil)
+				}, 1, nil)
+			Ω(client.DestroyVMInstance(dummies.CSMachine1)).
+				Should(Succeed())
+		})
+
+		It("calls destroy without error and identifies it as expunged", func() {
+			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
+				Return(expungeDestroyParams)
+			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, nil)
+			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID).
+				Return(&cloudstack.VirtualMachinesMetric{
+					State: "Expunged",
+				}, 1, nil)
 			Ω(client.DestroyVMInstance(dummies.CSMachine1)).
 				Should(Succeed())
 		})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR modifies the VM deletion behavior so that if a CloudStack VM is expunging or expunged, it will be considered "deleted" from the CAPC perspective

*Testing performed:*
Ginkgo unit tests pass
TODO: manual e2e testing with clusterctl/tilt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->