### PR TITLE
Fix failed e2e tests

### DIFF
--- a/pkg/cloud/cluster.go
+++ b/pkg/cloud/cluster.go
@@ -129,9 +129,12 @@ func (c *client) ResolveDomainAndAccount(csCluster *infrav1.CloudStackCluster) e
 		listAccountResp, retErr := c.cs.Account.ListAccounts(listAccountParams)
 		if retErr != nil {
 			return retErr
-		} else if listAccountResp.Count != 1 {
+		} else if listAccountResp.Count == 0 {
+			return errors.Errorf("could not find account %s in domain ID %s",
+				csCluster.Spec.Account, csCluster.Status.DomainID)
+		} else if listAccountResp.Count > 1 {
 			return errors.Errorf("expected 1 Account with account name %s in domain ID %s, but got %d",
-				csCluster.Spec.Account, csCluster.Status.DomainID, resp.Count)
+				csCluster.Spec.Account, csCluster.Status.DomainID, listAccountResp.Count)
 		}
 	}
 	return nil

--- a/test/e2e/invalid_resource.go
+++ b/test/e2e/invalid_resource.go
@@ -66,7 +66,7 @@ func InvalidResourceSpec(ctx context.Context, inputGetter func() CommonSpecInput
 	})
 
 	It("Should fail due to the specified domain is not found [TC4b]", func() {
-		testInvalidResource(ctx, input, "invalid-domain", "No match found for "+input.E2EConfig.GetVariable(InvalidDomainName))
+		testInvalidResource(ctx, input, "invalid-domain", "domain not found for domain path "+input.E2EConfig.GetVariable(InvalidDomainName))
 	})
 
 	It("Should fail due to the specified control plane offering is not found [TC7]", func() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Two invalid resource tests (account and domain) are failing due to the recent changes in the code resolving domain and account. This PR fixes the failing tests

*Testing performed:*

Ran 7 of 18 Specs in 734.755 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 11 Skipped
PASS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->