### PR TITLE
Fix CloudStackMachine Missing Finalizer

### DIFF
--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -143,20 +143,20 @@ func GetOwnerOfKind(ctx context.Context, c clientPkg.Client, owned clientPkg.Obj
 		return errors.Errorf(
 			"found more than one GVK for owner when finding owner kind for %s/%s", owned.GetName(), owned.GetNamespace())
 	}
-	kind := gvks[0].Kind
+	gvk := gvks[0]
+
 	for _, ref := range owned.GetOwnerReferences() {
-		if ref.Kind != kind {
+		if ref.Kind != gvk.Kind {
 			continue
 		}
 		key := clientPkg.ObjectKey{Name: ref.Name, Namespace: owned.GetNamespace()}
 		if err := c.Get(ctx, key, owner); err != nil {
-			return errors.Wrapf(err, "finding owner of kind %s %s/%s",
-				owner.GetObjectKind().GroupVersionKind().Kind, owner.GetNamespace(), owner.GetName())
+			return errors.Wrapf(err, "finding owner of kind %s in namespace %s", gvk.Kind, owned.GetNamespace())
 		}
 		return nil
 	}
-	return errors.Errorf("couldn't find owner of kind %s %s/%s",
-		owner.GetObjectKind().GroupVersionKind().Kind, owner.GetNamespace(), owner.GetName())
+
+	return errors.Errorf("couldn't find owner of kind %s in namespace %s", gvk.Kind, owned.GetNamespace())
 }
 
 func ContainsNoMatchSubstring(err error) bool {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
If creating a VM returns an error, then the CSMachine finalizer isn't added to the CR.

When the CAPI machine is deleted, the CSMachine gets garbage collected without deleting a machine.

It's a bit of a strange paradigm that a VM gets created yet the creation method returns an error, but that's the case.

May want to by default just add finalizers in controllers in the future.

*Testing performed:*
Used an `Insane Instance` to incite an error on VM creation.

Watched as CAPC cycled VMs several times without continually creating them.
![image](https://user-images.githubusercontent.com/93345136/168673379-4a3a9a6a-4562-4b40-b60e-49ba3ebbfb5e.png)
![image](https://user-images.githubusercontent.com/93345136/168673413-ee87e17e-0a5b-4cfd-bb87-48c00c3982b3.png)
![image](https://user-images.githubusercontent.com/93345136/168673433-1cf4d16d-acf1-4c9b-a77f-64d8676987e5.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->