### PR TITLE
Check VM instance ID is nil when deleting CS machine

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -249,6 +249,10 @@ func (r *CloudStackMachineReconciliationRunner) GetOrCreateMachineStateChecker()
 }
 
 func (r *CloudStackMachineReconciliationRunner) ReconcileDelete() (retRes ctrl.Result, reterr error) {
+	if r.ReconciliationSubject.Spec.InstanceID == nil {
+		r.Log.Info("VM Instance ID is nil")
+		return ctrl.Result{}, nil
+	}
 	r.Log.Info("Deleting instance", "instance-id", r.ReconciliationSubject.Spec.InstanceID)
 	// Use CSClient instead of CSUser here to expunge as admin.
 	// The CloudStack-Go API does not return an error, but the VM won't delete with Expunge set if requested by
@@ -260,7 +264,7 @@ func (r *CloudStackMachineReconciliationRunner) ReconcileDelete() (retRes ctrl.R
 		}
 		return ctrl.Result{}, err
 	}
-	r.Log.Info("VM Deleted.")
+	r.Log.Info("VM Deleted")
 	controllerutil.RemoveFinalizer(r.ReconciliationSubject, infrav1.MachineFinalizer)
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When testing invalid resource e2e tests the following panic occurs. 

```
E0517 02:11:00.441083       1 controller.go:317] controller/cloudstackmachine "msg"="Reconciler error" "error"="1 error occurred:\n\t* could not get Service Offering ID from OfferingXXXX: No match found for OfferingXXXX: &{Count:0 ServiceOfferings:[]}\n\n" "name"="invalid-resource-rn649v-control-plane-kjgsb" "namespace"="invalid-resource-4v8304" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="CloudStackMachine"
I0517 02:11:10.727219       1 cloudstackmachine_controller.go:252] controllers "msg"="Deleting instance" "name"="invalid-resource-rn649v-control-plane-kjgsb" "namespace"="invalid-resource-4v8304" "instance-id"=null
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x166e2f7]

goroutine 519 [running]:
github.com/aws/cluster-api-provider-cloudstack/pkg/cloud.(*client).DestroyVMInstance(0xc0004e9860, 0xc000fd3600)
	/Users/wonkun/dev/pike/cluster-api-provider-cloudstack/pkg/cloud/instance.go:255 +0x57
github.com/aws/cluster-api-provider-cloudstack/controllers.(*CloudStackMachineReconciliationRunner).ReconcileDelete(0xc00077b680)
```

Looks like https://github.com/aws/cluster-api-provider-cloudstack/pull/92 change adds machine finalizer when creating VM instance doesn't occur because of a certain invalid resource (e.g. service offering ID not found). Therefore, reconcileDelete is called with nil InstanceID. Missing the nil check caused this panic. 

*Testing performed:*
```
JOB="specified" make run-e2e
```
Passed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->